### PR TITLE
Fixed missing flash messages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
     alert_type = {
       alert: 'danger',
       notice: 'info'
-    }.fetch(alert_type, alert_type.to_s)
+    }.with_indifferent_access.fetch(alert_type, alert_type.to_s)
     "alert-#{alert_type}"
   end
 


### PR DESCRIPTION
Flash messages disappeared from main layout because Rails 4 HashWithIndifferentAccess#each was returning Strings for keys.
