### PR TITLE
Fixing gem grouping and simplecov version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,21 +29,20 @@ end
 
 group :test do
   gem 'fuubar', '~> 2.0.0.beta1'
-end
-
-group :test, :development do
-  gem 'rspec-rails', '~> 3.0.0.beta2'
+  gem 'jasminerice', github: 'bradphelan/jasminerice' # Latest release still depends on haml.
   gem 'capybara', github: 'jnicklas/capybara' # Rspec 3 deprecations, waiting for the next gem release.
   #gem 'capybara-email'
   gem 'poltergeist'
   gem 'factory_girl_rails'
-  gem 'database_cleaner'
-  gem 'jasminerice', github: 'bradphelan/jasminerice' # Latest release still depends on haml.
   #gem 'timecop'
-  gem 'simplecov', '0.7.1'
+  gem 'database_cleaner'
+  gem 'simplecov', '~> 0.7.1' # https://github.com/colszowka/simplecov/issues/281
+end
+
+group :test, :development do
+  gem 'rspec-rails', '~> 3.0.0.beta2'
   #gem 'cane'
   #gem 'morecane'
-  #gem 'quiet_assets'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,7 +299,7 @@ DEPENDENCIES
   rspec-rails (~> 3.0.0.beta2)
   sass-rails
   simple_form (~> 3.0)
-  simplecov (= 0.7.1)
+  simplecov (~> 0.7.1)
   slim-rails
   therubyracer
   turbolinks


### PR DESCRIPTION
This fixes two warnings/errors:

The latest simplecov is not working properly (see colszowka/simplecov#281), and it calls `exit` within a `Kernel.at_exit`, which causes irb to explode on exit.

With fuubar in the development group, this warning is logged on irb start, because fuubar requires rspec:
`irb: warn: can't alias context from irb_context.`

On a related note, should more of the gems in the :development/:test combined group be moved to only test? For example, I see jasminerice routes in `rake routes`
