### PR TITLE
Switched environment variable for cookie secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Continuous deployment from the build server is highly recommended.
 
 Several common features and operational parameters can be set using environment variables. These are all optional.
 
-* ```SECRET_TOKEN``` - Secret key base for verfying signed cookies. Should be 30+ random characters and secret!
+* ```SECRET_KEY_BASE``` - Secret key base for verfying signed cookies. Should be 30+ random characters and secret!
 * ```HOSTNAME``` - Canonical hostname for this application. Other incoming requests will be redirected to this hostname.
 * ```BASIC_AUTH_PASSWORD``` - Enable basic auth with this password.
 * ```BASIC_AUTH_USER``` - Set a basic auth username (not required, password enables basic auth).

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -12,4 +12,4 @@
 
 # Default key is useful for test and development, but should
 # absolutely be overriden in production.
-AppPrototype::Application.config.secret_key_base = ENV['SECRET_TOKEN'] || 'AWAbYFxfy5SxropZl5yIiNiE2bv3lJ7nLcreGI9p'
+AppPrototype::Application.config.secret_key_base = ENV['SECRET_KEY_BASE'] || 'AWAbYFxfy5SxropZl5yIiNiE2bv3lJ7nLcreGI9p'


### PR DESCRIPTION
Heroku automatically sets a variable named SECRET_KEY_BASE, so
we might as well use it.
