### PR TITLE
Fix indentation in Slim index view

### DIFF
--- a/lib/templates/slim/scaffold/index.html.slim
+++ b/lib/templates/slim/scaffold/index.html.slim
@@ -11,20 +11,20 @@ table.table.table-striped
     th Actions
 
   tbody
-  - @<%= plural_table_name %>.each do |<%= singular_table_name %>|
-    tr
-      /td= link_to_if can?(:show, <%= singular_table_name %>), <%= singular_table_name %>.id, <%= singular_table_name %>_path(<%= singular_table_name %>)
-      td= link_to <%= singular_table_name %>.id, <%= singular_table_name %>_path(<%= singular_table_name %>)
-<% attributes.each do |attribute| -%>
-      td= <%= singular_table_name %>.<%= attribute.name %>
-<% end -%>
-      td
-        /- if can? :edit, <%= singular_table_name %>
-        = link_to text_with_icon('Edit', 'edit'), edit_<%= singular_table_name %>_path(<%= singular_table_name %>), class: 'btn btn-default btn-xs'
-        '
-        /- if can? :destroy, <%= singular_table_name %>
-        = link_to text_with_icon('Destroy', 'remove'), <%= singular_table_name %>_path(<%= singular_table_name %>), \
-                  method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-default btn-xs btn-danger'
+    - @<%= plural_table_name %>.each do |<%= singular_table_name %>|
+      tr
+        /td= link_to_if can?(:show, <%= singular_table_name %>), <%= singular_table_name %>.id, <%= singular_table_name %>_path(<%= singular_table_name %>)
+        td= link_to <%= singular_table_name %>.id, <%= singular_table_name %>_path(<%= singular_table_name %>)
+  <% attributes.each do |attribute| -%>
+        td= <%= singular_table_name %>.<%= attribute.name %>
+  <% end -%>
+        td
+          /- if can? :edit, <%= singular_table_name %>
+          = link_to text_with_icon('Edit', 'edit'), edit_<%= singular_table_name %>_path(<%= singular_table_name %>), class: 'btn btn-default btn-xs'
+          '
+          /- if can? :destroy, <%= singular_table_name %>
+          = link_to text_with_icon('Destroy', 'remove'), <%= singular_table_name %>_path(<%= singular_table_name %>), \
+                    method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-default btn-xs btn-danger'
 
 /- if can? :create, <%= singular_table_name.classify %>
 = link_to text_with_icon('New <%= human_name %>', 'plus'), new_<%= singular_table_name %>_path, class: 'btn btn-primary'


### PR DESCRIPTION
The Slim index scaffold template currently renders an empty `tbody` section followed by the table contents, like so:

```
<tbody>
</tbody>
<tr><td>...</td></tr>
```

This patch fixes the template's indentation to properly wrap the table body with the `tbody` tag.
