### PR TITLE
Add RSpec generator template for models

### DIFF
--- a/lib/templates/rspec/model/model_spec.rb
+++ b/lib/templates/rspec/model/model_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+<% module_namespacing do -%>
+describe <%= class_name %> do
+  pending "add some examples to (or delete) #{__FILE__}"
+end
+<% end -%>


### PR DESCRIPTION
rspec-rails 3 has split its helpers into a `spec_helper` and a `rails_helper`. Its default generator templates all now require `rails_helper`, which does not exist in Raygun projects (which instead use a monolithic `spec_helper`).

This patch is a twofer:
1. It requires `spec_helper` instead of `rails_helper` in model specs, allowing much rejoicing from the elimination of repetitive busywork.
2. Following the lead of the controller and view spec templates, the model scaffold template restores the "classic" (inferred type) RSpec DSL.
