### PR TITLE
Jasmine-rails for js unit testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ end
 
 group :test do
   gem 'fuubar'
-  gem 'jasminerice', github: 'bradphelan/jasminerice'  # Latest release still depends on haml.
   gem 'capybara'
   #gem 'capybara-email'
   gem 'poltergeist'
@@ -37,6 +36,7 @@ end
 
 group :test, :development do
   gem 'rspec-rails'
+  gem 'jasmine-rails'
   #gem 'cane'
   #gem 'morecane'
 end
@@ -51,7 +51,6 @@ group :development do
   gem 'quiet_assets'
   gem 'guard', '~> 2'
   gem 'guard-rspec'
-  gem 'guard-jasmine'
   gem 'guard-livereload'
   gem 'rb-fsevent'
   gem 'growl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: git://github.com/bradphelan/jasminerice.git
-  revision: 091349c27343bfa728b8e5745675f9ddbb7d9699
-  specs:
-    jasminerice (0.1.0)
-      coffee-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -63,8 +56,6 @@ GEM
       xpath (~> 2.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    childprocess (0.5.5)
-      ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (4.1.0)
@@ -107,12 +98,6 @@ GEM
       lumberjack (~> 1.0)
       pry (>= 0.9.12)
       thor (>= 0.18.1)
-    guard-jasmine (1.19.2)
-      childprocess
-      guard (>= 2.0.0)
-      multi_json
-      thor
-      tilt
     guard-livereload (2.4.0)
       em-websocket (~> 0.5)
       guard (~> 2.8)
@@ -127,12 +112,18 @@ GEM
     hike (1.2.3)
     hitimes (1.2.2)
     http_parser.rb (0.6.0)
-    i18n (0.7.0.beta1)
+    i18n (0.7.0)
+    jasmine-core (2.1.3)
+    jasmine-rails (0.10.6)
+      jasmine-core (>= 1.3, < 3.0)
+      phantomjs
+      railties (>= 3.1.0)
+      sprockets-rails
     jquery-rails (4.0.0)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0.beta, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.1)
+    json (1.8.2)
     kgio (2.9.2)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -147,12 +138,13 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.4.3)
-    mini_portile (0.6.1)
-    minitest (5.4.3)
+    mini_portile (0.6.2)
+    minitest (5.5.1)
     multi_json (1.10.1)
-    nokogiri (1.6.5)
+    nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pg (0.17.1)
+    phantomjs (1.9.8.0)
     poltergeist (1.5.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -164,11 +156,11 @@ GEM
       slop (~> 3.4)
     quiet_assets (1.0.3)
       railties (>= 3.1, < 5.0)
-    rack (1.6.0.beta2)
+    rack (1.6.0)
     rack-canonical-host (0.1.0)
       addressable
       rack (~> 1.0)
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.0.rc2)
       actionmailer (= 4.2.0.rc2)
@@ -252,7 +244,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.2.2)
+    sprockets-rails (2.2.4)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
@@ -291,11 +283,10 @@ DEPENDENCIES
   fuubar
   growl
   guard (~> 2)
-  guard-jasmine
   guard-livereload
   guard-rspec
   heroku_rails_deflate
-  jasminerice!
+  jasmine-rails
   jquery-rails
   launchy
   pg

--- a/Guardfile
+++ b/Guardfile
@@ -26,9 +26,8 @@ guard :rspec, cmd: 'bin/rspec' do
   watch(%r{^app/views/(.+)/.*(\.slim)$}) { |m| "spec/requests/#{m[1]}_spec.rb" }
 end
 
-guard :jasmine do
-  watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$}) { 'spec/javascripts' }
-  watch(%r{spec/javascripts/.+_spec\.(js\.coffee|js|coffee)$})
-  watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)(?:\.\w+)*$}) { |m| "spec/javascripts/#{ m[1] }_spec.#{ m[2] }" }
-end
- 
+# guard :jasmine do
+#   watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$}) { 'spec/javascripts' }
+#   watch(%r{spec/javascripts/.+_spec\.(js\.coffee|js|coffee)$})
+#   watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)(?:\.\w+)*$}) { |m| "spec/javascripts/#{ m[1] }_spec.#{ m[2] }" }
+# end

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
 test:
   override:
-    - bundle exec rake spec:without_features spec:features
-    - bundle exec guard-jasmine
+    - bundle exec rake
   post:
     - bundle exec rake db:sample_data
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@ AppPrototype::Application.routes.draw do
 
   root to: 'pages#root'
 
+  mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
+
 end

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -16,42 +16,6 @@ rescue LoadError
   end
 end
 
-begin
-  require 'guard/jasmine/task'
-
-  namespace :spec do
-    desc "Run all javascript specs"
-    task :javascripts do
-      begin
-        ::Guard::Jasmine::CLI.start([])
-
-      rescue SystemExit => e
-        case e.status
-          when 1
-            fail "Some specs have failed."
-          when 2
-            fail "The spec couldn't be run: #{e.message}."
-        end
-      end
-    end
-
-    desc 'Runs specs with coverage and cane checks'
-    task cane: ['spec:enable_coverage', 'spec:coverage', 'quality']
-  end
-
-  Rake::Task['spec'].enhance do
-    Rake::Task['spec:javascripts'].invoke
-  end
-
-rescue LoadError
-  namespace :spec do
-    task :javascripts do
-      puts "Guard is not available in this environment: #{Rails.env}."
-    end
-  end
-end
-
-
 Rake::Task['spec'].clear_actions
 
 desc 'Runs all specs'

--- a/spec/javascripts/spec.css
+++ b/spec/javascripts/spec.css
@@ -1,3 +1,0 @@
-/*
- *=require application
- */

--- a/spec/javascripts/spec.js.coffee
+++ b/spec/javascripts/spec.js.coffee
@@ -1,2 +1,0 @@
-#=require application
-#=require_tree ./

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,52 @@
+use_phantom_gem: false
+
+# path to parent directory of src_files
+# relative path from Rails.root
+# defaults to app/assets/javascripts
+src_dir: "app/assets/javascripts"
+
+# path to additional directory of source file that are not part of assets pipeline and need to be included
+# relative path from Rails.root
+# defaults to []
+# include_dir:
+#   - ../mobile_app/public/js
+
+# path to parent directory of css_files
+# relative path from Rails.root
+# defaults to app/assets/stylesheets
+css_dir: "app/assets/stylesheets"
+
+# list of file expressions to include as source files
+# relative path from src_dir
+src_files:
+ - "application.{js.coffee,js,coffee}"
+
+# list of file expressions to include as css files
+# relative path from css_dir
+css_files:
+
+# path to parent directory of spec_files
+# relative path from Rails.root
+#
+# Alternatively accept an array of directory to include external spec files
+# spec_dir:
+#   - spec/javascripts
+#   - ../engine/spec/javascripts
+#
+# defaults to spec/javascripts
+spec_dir: spec/javascripts
+
+# list of file expressions to include as helpers into spec runner
+# relative path from spec_dir
+helpers:
+  - "helpers/**/*.{js.coffee,js,coffee}"
+
+# list of file expressions to include as specs into spec runner
+# relative path from spec_dir
+spec_files:
+  - "**/*[Ss]pec.{js.coffee,js,coffee}"
+
+# path to directory of temporary files
+# (spec runner and asset cache)
+# defaults to tmp/jasmine
+tmp_dir: "tmp/jasmine"


### PR DESCRIPTION
Raygun currently uses a combination of jasime, jasmine-rice (for rails asset pipeline support), and guard-jasmine (for a command line and guard spec runner). Jasminerice is no longer being maintained. Should raygun stick with this toolset for JS Unit Testing or is it time to shift towards something else?

We build node apps, traditional rails apps, and js front-ends for rails backends. Is there a JS unit testing stack that is the same, or similar enough, so that it's comfortable as a developer moving between the different kinds of projects.

Requirements:
* Run a single spec, or all specs, from the command line
* Headless
* In-browser runner

What else?
