### PR TITLE
Add autoprefixer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'jquery-rails'
 gem 'coffee-rails'
 gem 'simple_form'
 gem 'uglifier'
+gem 'autoprefixer-rails'
 
 gem 'awesome_print'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  autoprefixer-rails
   awesome_print
   better_errors
   binding_of_caller

--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,7 @@
+# Browsers supported by autoprefixer
+# See the browserslist docs for a full list of options
+# https://github.com/ai/browserslist
+
+last 2 versions
+# > 1%
+# IE 10


### PR DESCRIPTION
Should we include a sample `browserslist` config with some sensible defaults or is it enough that the gem is there?  Also does this warrant a mention in the README?

Lemme know what you think.