### PR TITLE
Enable aggregate failures unless explcitly disabled at the spec level.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,12 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  # Enable aggregate failures unless explcitly disabled at the spec level.
+  # See http://rspec.info/blog/2015/06/rspec-3-3-has-been-released/#expectations-new-aggregratefailures-api
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
+  end
+
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
 


### PR DESCRIPTION
See http://rspec.info/blog/2015/06/rspec-3-3-has-been-released/#expectations-new-aggregratefailures-api for more information.

I like the features for the reasons outlined in the blog post, and sometimes, having a few highly related expectations next to each other is more readable to me than separating them out. I'm not a strict "one expect per spec" developer, though I think there should be very few in general (and most often one).

I also like turning it on globally because a) the block syntax adds noise to a spec that has nothing to do with asserting behavior and b) turning it on per spec can lead to confusion because rspec will behave differently in different cases.

In my ideal work, rspec would turn this on a global default.