### PR TITLE
Dump Rack::Lock for development because we use puma

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,4 +41,9 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
   
+  # Disable Rack::Lock because we are using Puma (even in development)
+  # If you setup your dev enviroment to use a different multi process server (like Unicorn),
+  # you should comment this line
+  config.middleware.delete "Rack::Lock"  
+
 end


### PR DESCRIPTION
Turns off Rack::Lock with the assumption that even in your development environment, you're running Puma.

We found this switch to improve performance hiccups during development.
For more reading, check out:

http://tenderlovemaking.com/2012/06/18/removing-config-threadsafe.html
http://guides.rubyonrails.org/rails_on_rack.html

This also presumes that you're writing threadsafe code.

Moderately tested in a development environment.  It can get in the way of `binding.pry` inspection.  Not sure if that makes it a no go.  

Alternatively, maybe we add it to the environment commented out, and make the note read "you could add this in if you are using puma and ..."