### PR TITLE
Specifying dyno type when scaling Heroku workers

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -21,10 +21,11 @@ if [ $REMOTE_MISSING -eq 0 ] ; then
 fi
 
 PREV_WORKERS=$(heroku ps --app $APP_NAME | grep "^worker." | wc -l | xargs)
+WORKER_DYNO_TYPE=$(heroku ps:type -a $APP_NAME | grep "^worker" | awk '{print $2}')
 
 heroku maintenance:on --app $APP_NAME
 
-heroku scale worker=0 --app $APP_NAME
+heroku scale worker=0:$WORKER_DYNO_TYPE --app $APP_NAME
 
 # This little hacky morsel gets around a change in the latest git client.
 # A better solution is in the works (we hope).
@@ -34,6 +35,6 @@ git push -f heroku $SHA_TO_DEPLOY:refs/heads/master
 
 heroku run rake db:migrate db:seed --app $APP_NAME
 
-heroku scale worker=$PREV_WORKERS --app $APP_NAME
+heroku scale worker=$PREV_WORKERS:$WORKER_DYNO_TYPE --app $APP_NAME
 
 heroku maintenance:off --app $APP_NAME


### PR DESCRIPTION
Without this change (at least on my project), Heroku was assuming
we were attempting to scale to a different dyno type, and erroring
with: "Cannot use the following dyno types in the same app"