### PR TITLE
Load seeds after database cleaner truncates

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -4,6 +4,7 @@
 RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
+    Rails.application.load_seed
   end
 
   config.before(:each) do
@@ -20,5 +21,8 @@ RSpec.configure do |config|
 
   config.after(:each) do
     DatabaseCleaner.clean
+    if DatabaseCleaner.connections.any? { |connection| connection.strategy.is_a? DatabaseCleaner::Generic::Truncation }
+      Rails.application.load_seed
+    end
   end
 end


### PR DESCRIPTION
We added a few seeds to our project and noticed that some tests failed because our seed wasn't there.

# Our Approach
We updated the database cleaner configuration to load seeds after the initial truncation, and then to re-run them any time `clean` has run with the `truncate` strategy.

## Cons
* The line that checks whether the strategy was truncation is wordier than I would like. I didn't see a cleaner way to do it.
* May slow down tests. However, it only added 3 seconds to our 2.5-minute suite with a simple seeds file of 9 models.

# Other Possible Approaches
I think our approach is pleasantly general. But we considered a couple of other options.

* If you have seeds in specific tables and you don't ever create additional data in those tables, you could just configure database cleaner to exclude those tables.
* If most tests don't need the seeds there, you can just create the data with factories in those that do.