### PR TITLE
Update circle.yml to specify `bundle exec`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,10 @@
 test:
   override:
     # Default task run all specs.
-    - rake
+    - bundle exec rake
   post:
     # Make sure sample_data still runs correctly, since it's easy to miss.
-    - rake db:sample_data
+    - bundle exec rake db:sample_data
 
 deployment:
   acceptance:


### PR DESCRIPTION
After firing up a raygun skeleton, and pushing to CircleCI, I got the report from circle that:

```
rake aborted!
Gem::LoadError: You have already activated rake 10.4.2, but your Gemfile requires rake 10.5.0. Prepending `bundle exec` to your command may solve this.
```

My `Gemfile.lock` shows `rake (10.5.0)` and apparently the CircleCI system rake is not quite so up to date. 

This fix adds `bundle exec` to the both `rake` and `rake db:sample_data` commands to set CircleCI straight.