### PR TITLE
Use truncation strategy for all features, not just js specs

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -10,7 +10,7 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
-  config.before(:each, js: true) do
+  config.before(:each, type: :feature) do
     DatabaseCleaner.strategy = :truncation
   end
 


### PR DESCRIPTION
This resolves the intermittent failures we've been seeing on Eden when there're both js/non-js feature specs.