### PR TITLE
DB helper scripts for resetting databases to known states.

### DIFF
--- a/bin/reset-acceptance-with-production-data.sh
+++ b/bin/reset-acceptance-with-production-data.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
-set -x
 source "reset-config.cfg"
+
+echo "Copying production data to acceptance (destructive)..."
+sleep 3
+
+set -x
 
 heroku pg:copy $PRODUCTION::DATABASE_URL DATABASE_URL --confirm $ACCEPTANCE

--- a/bin/reset-acceptance-with-production-data.sh
+++ b/bin/reset-acceptance-with-production-data.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -x
+source "reset-config.cfg"
+
+heroku pg:copy $PRODUCTION::DATABASE_URL DATABASE_URL --confirm $ACCEPTANCE

--- a/bin/reset-acceptance-with-sample-data.sh
+++ b/bin/reset-acceptance-with-sample-data.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -x
+source "reset-config.cfg"
+
+heroku pg:reset DATABASE_URL --confirm $ACCEPTANCE
+heroku run rake db:migrate -a $ACCEPTANCE
+heroku run rake db:seed db:sample_data -a $ACCEPTANCE

--- a/bin/reset-acceptance-with-sample-data.sh
+++ b/bin/reset-acceptance-with-sample-data.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
-set -x
 source "reset-config.cfg"
+
+echo "Loading sample_data on acceptance (destructive)..."
+sleep 3
+
+set -x
 
 heroku pg:reset DATABASE_URL --confirm $ACCEPTANCE
 heroku run rake db:migrate -a $ACCEPTANCE

--- a/bin/reset-config.cfg
+++ b/bin/reset-config.cfg
@@ -1,0 +1,4 @@
+APP_NAME="app-prototype"
+DB_NAME="app_prototype"
+PRODUCTION="$APP_NAME"
+ACCEPTANCE="${PRODUCTION}-acceptance"

--- a/bin/reset-development-with-production-data.sh
+++ b/bin/reset-development-with-production-data.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -x
+source "reset-config.cfg"
+
+DEVELOPMENT_DB="${DB_NAME}_development"
+
+rake db:drop
+heroku pg:pull DATABASE_URL $DEVELOPMENT_DB -a $PRODUCTION

--- a/bin/reset-development-with-production-data.sh
+++ b/bin/reset-development-with-production-data.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
-set -x
 source "reset-config.cfg"
 
+echo "Loading production data in development(destructive)..."
+sleep 3
+
 DEVELOPMENT_DB="${DB_NAME}_development"
+
+set -x
 
 rake db:drop
 heroku pg:pull DATABASE_URL $DEVELOPMENT_DB -a $PRODUCTION


### PR DESCRIPTION
[updated to reflect latest commits...]

I find myself often messing resetting my local and acceptance dbs either to a known small set of data (e.g. sample_data) or to a large set of data (e.g. production). These scripts make that easy...

* reset-acceptance-with-production-data.sh - overwrites acceptance db with production data.
* reset-acceptance-with-sample-data.sh - overwrites acceptance db with seeds and sample data.
* reset-development-with-production-data.sh - overwrite development db with production data.

