### PR TITLE
Add one-click Deploy to Heroku button to Raygun Rails app template

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Generated with [Raygun](https://github.com/carbonfive/raygun).
 
 ## Getting Started
 
+### tl;dr
+One click to deploy this as a free Heroku app, but note that you'll need to perform the setup below to work on it locally.
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ### Requirements
 
 To run the specs or fire up the server, be sure you have these installed (and running):

--- a/app.json
+++ b/app.json
@@ -1,0 +1,9 @@
+{
+  "name": "Raygun Rails App Template",
+  "description": "Rails application generator that builds applications with the common customization stuff already done.",
+  "repository": "https://github.com/crcastle/raygun-rails",
+  "website": "https://github.com/carbonfive/raygun",
+  "logo": "https://raw.github.com/carbonfive/raygun/master/marvin.jpg",
+  "keywords": ["ruby", "rails", "template", "raygun", "carbonfive"],
+  "success_url": "/"
+}

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "Raygun Rails App Template",
   "description": "Rails application generator that builds applications with the common customization stuff already done.",
-  "repository": "https://github.com/crcastle/raygun-rails",
+  "repository": "https://github.com/carbonfive/raygun-rails",
   "website": "https://github.com/carbonfive/raygun",
   "logo": "https://raw.github.com/carbonfive/raygun/master/marvin.jpg",
   "keywords": ["ruby", "rails", "template", "raygun", "carbonfive"],

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,7 @@
 class PagesController < ApplicationController
 
   def root
+    @on_heroku = !ENV['DYNO'].nil?
   end
 
 end

--- a/app/views/pages/root.html.slim
+++ b/app/views/pages/root.html.slim
@@ -7,7 +7,12 @@ javascript:
 .jumbotron
   h1 Hello, world!
   br
-  p Welcome to your newly generated rails application...
+  - if @on_heroku
+    p Welcome to your newly generated rails application... deployed to heroku!
+  - else
+    p Welcome to your newly generated rails application...
+
   p Meander around the code to see what's been done for you. Many small, and a few not-so-small, customizations have been made.
   p Custom generator templates create views that are bootstrap compatible and specs that are factory-aware and follow best practices.
-  p Your application is ready for easy deployment to heroku.
+  - unless @on_heroku
+    p Your application is ready for easy deployment to heroku.


### PR DESCRIPTION
Thought it might be interesting to give people a one-click deploy option to see the template live, even though there's not much to see.

Also (and maybe more interestingly), this would allow anyone who uses the [raygun generator](https://github.com/carbonfive/raygun) to deploy their own customized app with one click.

Changes include:
- Add tl;dr section and "Deploy to Heroku" button to README
- Add a little conditional logic to root page view and controller to determine if we are on heroku or not

Comments or changes welcome if you want the button incorporated in a different way!