### PR TITLE
disabling sass in benefit of sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'pg'
 
 gem 'slim-rails'
 gem 'sassc-rails'
+gem 'sass-rails', require: false
 gem 'bootstrap-sass'
 gem 'jquery-rails'
 gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,12 @@ GEM
     rspec-support (3.5.0)
     ruby_dep (1.3.1)
     sass (3.4.22)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
     sassc (1.10.0)
       bundler
       ffi (~> 1.9.6)
@@ -249,6 +255,7 @@ DEPENDENCIES
   rack-timeout
   rails (~> 5.0)
   rspec-rails
+  sass-rails
   sassc-rails
   simple_form
   simplecov


### PR DESCRIPTION
First of all, thank you guys for sharing it!

I just created a new project using raygun and when tried to run:

`rails generate controller <controller_name>`

I got an error: "sass not found"

In order to Rails use `sassc` it was need to disable `saas`
