### PR TITLE
added missing dotenv gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ end
 group :test, :development do
   gem 'rspec-rails'
   gem 'factory_girl_rails'
+  gem 'dotenv'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ end
 group :test, :development do
   gem 'rspec-rails'
   gem 'factory_girl_rails'
-  gem 'dotenv'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    dotenv (2.1.1)
     erubis (2.7.0)
     execjs (2.7.0)
     factory_girl (4.7.0)
@@ -237,6 +238,7 @@ DEPENDENCIES
   capybara
   coffee-rails
   database_cleaner
+  dotenv
   factory_girl_rails
   foreman
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,9 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.7.0)
     factory_girl (4.7.0)
@@ -238,7 +241,7 @@ DEPENDENCIES
   capybara
   coffee-rails
   database_cleaner
-  dotenv
+  dotenv-rails
   factory_girl_rails
   foreman
   jquery-rails


### PR DESCRIPTION
Hi guys
another small suggestion: since you already have added a `.env` file, I thought it would be also a good idea to have it loaded by default using `dotenv` gem.
Cheers.
