### PR TITLE
Use relative path sourcing for more flexibility

### DIFF
--- a/bin/reset-acceptance-with-production-data.sh
+++ b/bin/reset-acceptance-with-production-data.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-source "reset-config.cfg"
+cwd=`dirname "$0"`
+source "$cwd/reset-config.cfg"
 
 echo "Copying production data to acceptance (destructive)..."
 sleep 3

--- a/bin/reset-acceptance-with-sample-data.sh
+++ b/bin/reset-acceptance-with-sample-data.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-source "reset-config.cfg"
+cwd=`dirname "$0"`
+source "$cwd/reset-config.cfg"
 
 echo "Loading sample_data on acceptance (destructive)..."
 sleep 3

--- a/bin/reset-development-with-production-data.sh
+++ b/bin/reset-development-with-production-data.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-source "reset-config.cfg"
+cwd=`dirname "$0"`
+source "$cwd/reset-config.cfg"
 
 echo "Loading production data in development(destructive)..."
 sleep 3


### PR DESCRIPTION
I found these reset data scripts don't work from `Rails.root` they can't find that `reset_config.cfg` file.  This change adds relative path sourcing for that file so assuming it lives next door to the scripts they can be run from `Rails.root` with `bin/reset-acceptance...whatever.sh`.