### PR TITLE
Deploy should fail if rake db:migrate fails

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -37,7 +37,7 @@ heroku maintenance:on --app $APP_NAME
 
 git push -f heroku $SHA_TO_DEPLOY:refs/heads/master
 
-heroku run rake db:migrate db:seed --app $APP_NAME
+heroku run -x --app $APP_NAME -- rake db:migrate db:seed
 
 heroku maintenance:off --app $APP_NAME
 


### PR DESCRIPTION
Previously, if `rake db:migrate` failed during the deploy script, the deploy would continue as if nothing had gone wrong. It seems to me that the deploy should fail in this scenario.

Fix by adding the `-x` flag to `heroku run`, which causes the heroku command to passthrough the exit code of the remote command.