### PR TITLE
Deploy script just needs to push to Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web:    bundle exec puma -C config/puma.rb
+release: bundle exec rake db:migrate db:seed
 #worker: bundle exec rake jobs:work

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -20,13 +20,6 @@ if [ $REMOTE_MISSING -eq 0 ] ; then
   git remote add heroku git@heroku.com:$APP_NAME.git
 fi
 
-PREV_WORKERS=$(heroku ps --app $APP_NAME | grep "^worker." | wc -l | xargs)
-WORKER_DYNO_TYPE=$(heroku ps:type -a $APP_NAME | grep "^worker" | awk '{print $2}')
-
-heroku scale worker=0:$WORKER_DYNO_TYPE --app $APP_NAME
-
-heroku maintenance:on --app $APP_NAME
-
 # CircleCI makes a shallow clone to reduce network bandwidth. Pushing from a
 # shallow clone often works, but it can fail since shallow clones don't have
 # the full history. The error message looks like:
@@ -36,9 +29,3 @@ heroku maintenance:on --app $APP_NAME
 [ ! -s "$(git rev-parse --git-dir)/shallow" ] || git fetch --unshallow
 
 git push -f heroku $SHA_TO_DEPLOY:refs/heads/master
-
-heroku run rake db:migrate db:seed --app $APP_NAME
-
-heroku maintenance:off --app $APP_NAME
-
-heroku scale worker=$PREV_WORKERS:$WORKER_DYNO_TYPE --app $APP_NAME


### PR DESCRIPTION
# Problem

We have encountered two issues with the deploy script:

* Referenced in https://github.com/carbonfive/raygun-rails/pull/83: If migrations or seeds fail, the script's exit code should reflect the error.
* If a deploy fails, the worker dyno count remains at 0, and a subsequent successful deploy will not scale workers back to the count before the botched deploy.

# Proposal

The deploy script can be simplified in two ways: 

1. Run migrations and seeds during the [release phase](https://devcenter.heroku.com/articles/release-phase)
2. Stop scaling workers manually because all dynos, including workers, [restart after a release](https://devcenter.heroku.com/articles/dynos#restarting).

It's probably preferable to deploy through CircleCI's Heroku integration, but it's handy to keep this script around for other scenarios.