### PR TITLE
Ensure test database is created properly

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -27,6 +27,7 @@ chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
+  system! "bin/rails db:create:all"
   system! "bin/rails db:setup db:sample_data"
 
   puts "\n== Removing old logs and tempfiles =="


### PR DESCRIPTION
This fixes a problem where RSpec+Rails were failing to automatically run pending database migrations when you invoke `rspec` or `rake spec`. In Rails 4.1+, Rails is supposed to detect when the test database schema is out of date and run migrations for you. Instead, we were seeing errors like:

```
Migrations are pending. To resolve this issue, run:

    bin/rails db:migrate RAILS_ENV=test
```

Ultimately I discovered that the problem was the test database was not created properly originally. Apparently for the automatic schema maintenance to work, there is some metadata that has to be written to the database. The best way to ensure this is to create the database via the `db:create:all` rake task.

I've updated our `bin/setup` script to do this.