### PR TITLE
[FEEDBACK] Consistent app naming across prod and acceptance

### DIFF
--- a/bin/reset-config.cfg
+++ b/bin/reset-config.cfg
@@ -1,4 +1,4 @@
 APP_NAME="app-prototype"
 DB_NAME="app_prototype"
-PRODUCTION="$APP_NAME"
-ACCEPTANCE="${PRODUCTION}-acceptance"
+PRODUCTION="$APP_NAME-production"
+ACCEPTANCE="$APP_NAME-acceptance"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,8 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: ENV["HOSTNAME"].presence || "app-prototype.herokuapp.com" }
+  config.action_mailer.default_url_options =
+    { host: ENV["HOSTNAME"].presence || "app-prototype-production.herokuapp.com" }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
Previously, production was named "app" and acceptance was "app-acceptance". This change favors consistency and explicitness by naming production to "app-production" in new apps.