### PR TITLE
Use headless chrome for features specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,8 @@ end
 group :test do
   gem "capybara"
   # gem "capybara-email"
+  gem "capybara-selenium"
   gem "database_cleaner"
-  gem "poltergeist"
   gem "simplecov"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    cliver (0.3.2)
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -125,10 +129,6 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.21.0)
-    poltergeist (1.16.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     public_suffix (3.0.0)
     puma (3.10.0)
@@ -196,6 +196,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    rubyzip (1.2.1)
     sass (3.5.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -218,6 +219,9 @@ GEM
       sprockets (> 2.11)
       sprockets-rails
       tilt
+    selenium-webdriver (3.6.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
     simple_form (3.5.0)
       actionpack (> 4, < 5.2)
       activemodel (> 4, < 5.2)
@@ -272,6 +276,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass
   capybara
+  capybara-selenium
   coffee-rails
   database_cleaner
   dotenv-rails
@@ -281,7 +286,6 @@ DEPENDENCIES
   launchy
   listen
   pg
-  poltergeist
   puma
   rack-canonical-host
   rack-timeout

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Generated with [Raygun](https://github.com/carbonfive/raygun).
 To run the specs or fire up the server, be sure you have these installed (and running):
 
 * Ruby 2.4 (see [.ruby-version](.ruby-version)).
-* PostgreSQL 9.x (`brew install postgresql`) with superuser 'postgres' with no password (`createuser -s postgres`).
-* Chromedriver for Capybara testing (`brew install chromedriver`). 
+* PostgreSQL 9.6+ (`brew install postgresql`) with superuser 'postgres' with no password (`createuser -s postgres`).
+* Chromedriver 2.3+ for Capybara testing (`brew install chromedriver`). 
 
 ### First Time Setup
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To run the specs or fire up the server, be sure you have these installed (and ru
 
 * Ruby 2.4 (see [.ruby-version](.ruby-version)).
 * PostgreSQL 9.6+ (`brew install postgresql`) with superuser 'postgres' with no password (`createuser -s postgres`).
-* Chromedriver 2.3+ for Capybara testing (`brew install chromedriver`). 
+* Chromedriver 2.3+ for Capybara testing (`brew install chromedriver`).
 
 ### First Time Setup
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To run the specs or fire up the server, be sure you have these installed (and ru
 
 * Ruby 2.4 (see [.ruby-version](.ruby-version)).
 * PostgreSQL 9.x (`brew install postgresql`) with superuser 'postgres' with no password (`createuser -s postgres`).
-* Chromedriver for Capybara testing (`brew install chromesriver`). 
+* Chromedriver for Capybara testing (`brew install chromedriver`). 
 
 ### First Time Setup
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To run the specs or fire up the server, be sure you have these installed (and ru
 
 * Ruby 2.4 (see [.ruby-version](.ruby-version)).
 * PostgreSQL 9.x (`brew install postgresql`) with superuser 'postgres' with no password (`createuser -s postgres`).
-* PhantomJS 2.x for Capybara testing (`brew install phantomjs`).
+* Chromedriver for Capybara testing (`brew install chromesriver`). 
 
 ### First Time Setup
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,12 +2,12 @@ require "selenium/webdriver"
 
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
-  options.add_argument("--headless")
-  options.add_argument("--window-size=1280,2000")
+  options.add_argument("headless")
+  options.add_argument("window-size=1280,2000")
 
   # Try this if chrome crashes.
   # https://sites.google.com/a/chromium.org/chromedriver/help/chrome-doesn-t-start
-  # options.add_argument("--no-sandbox")
+  # options.add_argument("no-sandbox")
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,15 +1,22 @@
 require "selenium/webdriver"
 
 Capybara.register_driver :headless_chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
-  options.add_argument("headless")
-  options.add_argument("window-size=1280,2000")
+  options = { "args" => %w[headless window-size=1024,3840] }
 
   # Try this if chrome crashes.
   # https://sites.google.com/a/chromium.org/chromedriver/help/chrome-doesn-t-start
-  # options.add_argument("no-sandbox")
+  # options["args"] << "no-sandbox"
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chrome_options: options,
+    logging_prefs: { "browser" => "ALL" }
+  )
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+  )
 end
 
 Capybara.default_driver    = :rack_test

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,13 +3,20 @@ require "selenium/webdriver"
 Capybara.register_driver :headless_chrome do |app|
   options = { "args" => %w[headless window-size=1024,3840] }
 
-  # Try this if chrome crashes.
-  # https://sites.google.com/a/chromium.org/chromedriver/help/chrome-doesn-t-start
+  # Try this if chrome crashes. https://sites.google.com/a/chromium.org/chromedriver/help/chrome-doesn-t-start
   # options["args"] << "no-sandbox"
+
+  # This enables access to the JS console logs in your feature specs.
+  # You can see the logs during the test by calling (for example):
+  #
+  #   puts page.driver.browser.manage.logs.get(:browser).map(&:inspect).join("\n")
+  #
+  # This will print out each log entry in the JS log, including e.g. the React welcome notice.
+  logging_prefs = { "browser" => "ALL" }
 
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chrome_options: options,
-    logging_prefs: { "browser" => "ALL" }
+    logging_prefs: logging_prefs
   )
 
   Capybara::Selenium::Driver.new(

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,6 +3,11 @@ require "selenium/webdriver"
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument("--headless")
+
+  # Try this if chrome crashes.
+  # https://sites.google.com/a/chromium.org/chromedriver/help/chrome-doesn-t-start
+  # options.add_argument("--no-sandbox")
+
   options.add_argument("--window-size=1280,1024")
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,4 +7,5 @@ Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
+Capybara.default_driver    = :rack_test
 Capybara.javascript_driver = :headless_chrome

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,8 +1,12 @@
-require "capybara/poltergeist"
+require "selenium/webdriver"
 
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, js_errors: true, inspector: true)
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
 
-Capybara.default_driver    = :rack_test
-Capybara.javascript_driver = :poltergeist
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: %w[headless] })
+  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
+end
+
+Capybara.javascript_driver = :headless_chrome

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,12 +1,10 @@
 require "selenium/webdriver"
 
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
-end
-
 Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: %w[headless] })
-  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless")
+  options.add_argument("--window-size=1280,1024")
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
 Capybara.javascript_driver = :headless_chrome

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,12 +3,12 @@ require "selenium/webdriver"
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument("--headless")
+  options.add_argument("--window-size=1280,2000")
 
   # Try this if chrome crashes.
   # https://sites.google.com/a/chromium.org/chromedriver/help/chrome-doesn-t-start
   # options.add_argument("--no-sandbox")
 
-  options.add_argument("--window-size=1280,1024")
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 


### PR DESCRIPTION
PhantomJS is no longer being maintained. Everyone is moving to headless Chrome, because it's the most popular browser and now runs in a headless mode.

There's some talk of switching over to Rails' 5.1's System Tests. That's probably a good idea, but it'll be another PR.