### PR TITLE
Rotate Rails log files to prevent them from growing forever

### DIFF
--- a/config/initializers/rotate_log.rb
+++ b/config/initializers/rotate_log.rb
@@ -1,0 +1,10 @@
+# Rotate development and test log files when they exceed 5 MB. Otherwise logs
+# will grow unbounded into gigabytes over the life of a project.
+if Rails.env.development? || Rails.env.test?
+  log_file = Rails.root.join("log", "#{Rails.env}.log")
+
+  if log_file.file? && log_file.size > 5_000_000
+    FileUtils.cp(log_file, "#{log_file}.1")
+    log_file.truncate(0)
+  end
+end


### PR DESCRIPTION
The development.log and test.log files accumulate logs whenever the app and its tests are run, database migrations are performed, etc. Over the course of a few months of working on a Rails project, one developer's log files can easily grow to exceed 1GB.

Rails has a built-in `log:clear` rake task to delete the log files, but developers have to remember to run this periodically. The task is also executed by `bin/setup` and `bin/update`, but again these are unlikely to be used once a developer is set up.

In my most recent raygun-generated project, my logs were already nearly 2GB:

```
$ du -sh log/*
185M	log/development.log
1.7G	log/test.log
```

This PR proposes an initializer that detects the size of the log files upon startup and rotates them (with one backup) to keep them under 5MB each. I like this solution because it happens automatically, and I don't have to worry about suddenly running out of disk space in the middle of development.