### PR TITLE
Install annotate gem and configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :test, :development do
 end
 
 group :development do
+  gem "annotate"
   gem "better_errors"
   gem "binding_of_caller"
   gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    annotate (2.7.2)
+      activerecord (>= 3.2, < 6.0)
+      rake (>= 10.4, < 13.0)
     arel (8.0.0)
     ast (2.3.0)
     autoprefixer-rails (7.1.6)
@@ -269,6 +272,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   autoprefixer-rails
   awesome_print
   better_errors

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,53 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require "annotate"
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      "routes"                     => "false",
+      "position_in_routes"         => "before",
+      "position_in_class"          => "before",
+      "position_in_test"           => "before",
+      "position_in_fixture"        => "before",
+      "position_in_factory"        => "before",
+      "position_in_serializer"     => "before",
+      "show_foreign_keys"          => "true",
+      "show_complete_foreign_keys" => "false",
+      "show_indexes"               => "true",
+      "simple_indexes"             => "false",
+      "model_dir"                  => "app/models",
+      "root_dir"                   => "",
+      "include_version"            => "false",
+      "require"                    => "",
+      "exclude_tests"              => "true",
+      "exclude_fixtures"           => "false",
+      "exclude_factories"          => "false",
+      "exclude_serializers"        => "false",
+      "exclude_scaffolds"          => "true",
+      "exclude_controllers"        => "true",
+      "exclude_helpers"            => "true",
+      "exclude_sti_subclasses"     => "false",
+      "ignore_model_sub_dir"       => "false",
+      "ignore_columns"             => nil,
+      "ignore_routes"              => nil,
+      "ignore_unknown_models"      => "false",
+      "hide_limit_column_types"    => "integer,boolean",
+      "hide_default_column_types"  => "json,jsonb,hstore",
+      "skip_on_db_migrate"         => "false",
+      "format_bare"                => "true",
+      "format_rdoc"                => "false",
+      "format_markdown"            => "false",
+      "sort"                       => "true",
+      "force"                      => "false",
+      "trace"                      => "false",
+      "wrapper_open"               => nil,
+      "wrapper_close"              => nil,
+      "with_comment"               => true
+    )
+  end
+
+  Annotate.load_tasks
+end


### PR DESCRIPTION
This PR proposes adding the `annotate` gem to the default raygun-rails template. This is a handy part of the Rails toolkit that automatically annotates your Rails code with a summary of the relevant portion of the database schema. This quick-reference has proven to be useful on previous projects.

For example, if I generate a migration to define a `User` model and the migrate the database:

```
$ bin/rails generate model user email:string:index password_digest:text
$ bin/rails db:migrate
```

Then the `annotate` gem will automatically document the schema at the top of `app/models/user.rb`, like this:

```ruby
# == Schema Information
#
# Table name: users
#
#  created_at      :datetime         not null
#  email           :string
#  id              :integer          not null, primary key
#  password_digest :text
#  updated_at      :datetime         not null
#
# Indexes
#
#  index_users_on_email  (email)
#

class User < ApplicationRecord
end
```

This comment is automatically kept up to date whenever you run `db:migrate`.

Factories and serializers (if present) will be annotated as well. This is configurable in `lib/tasks/auto_annotate_models.rake`.