### PR TITLE
Update Rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,8 @@
 require File.expand_path("../config/application", __FILE__)
 
 AppPrototype::Application.load_tasks
+
+if Rails.env.development? || Rails.env.test?
+  Rake::Task[:default].clear_prerequisites
+  task default: %i[spec rubocop]
+end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -2,7 +2,5 @@ begin
   require "rubocop/rake_task"
 
   RuboCop::RakeTask.new
-
-  task default: %i[spec rubocop]
 rescue LoadError # rubocop:disable Lint/HandleExceptions
 end

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -3,14 +3,14 @@ begin
   require "rspec/core/rake_task"
 
   namespace :spec do
-    desc "Run the code examples in spec/ except those in spec/features"
-    RSpec::Core::RakeTask.new(:without_features) do |t|
-      t.exclude_pattern = "spec/features/**/*_spec.rb"
+    desc "Run the code examples in spec/ except those in spec/system"
+    RSpec::Core::RakeTask.new(:without_system) do |t|
+      t.exclude_pattern = "spec/system/**/*_spec.rb"
     end
   end
 rescue LoadError
   namespace :spec do
-    task :without_features do
+    task :without_system do
     end
   end
 end


### PR DESCRIPTION
# Goals

1. Make the default task more discoverable by defining it in `Rakefile`, not `rubocop.rake`.
2. Update custom test task to run non-system specs.