### PR TITLE
Use `heroku local` instead of foreman

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # Set environment variables needed for development here. These values will be
 # used unless they're already set.
 #
-# http://ddollar.github.com/foreman/#ENVIRONMENT
+# https://devcenter.heroku.com/articles/heroku-local#set-up-your-local-environment-variables
 
 PORT=3000
 

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ group :development do
   gem "better_errors"
   gem "binding_of_caller"
   gem "dotenv-rails"
-  gem "foreman"
   gem "launchy"
   gem "spring"
   gem "spring-commands-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,8 +95,6 @@ GEM
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     ffi (1.9.18)
-    foreman (0.84.0)
-      thor (~> 0.19.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     i18n (0.9.1)
@@ -283,7 +281,6 @@ DEPENDENCIES
   coffee-rails
   dotenv-rails
   factory_bot_rails
-  foreman
   jquery-rails
   launchy
   listen

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To run the specs or fire up the server, be sure you have these installed (and ru
 * Ruby 2.4 (see [.ruby-version](.ruby-version)).
 * PostgreSQL 9.6+ (`brew install postgresql`) with superuser 'postgres' with no password (`createuser -s postgres`).
 * Chromedriver 2.3+ for Capybara testing (`brew install chromedriver`).
+* Heroku CLI (`brew install heroku`).
 
 ### First Time Setup
 
@@ -35,7 +36,9 @@ Note: `./bin/rake` runs the springified version of rake (there's a `./bin/rspec`
 
 ### Running the Application Locally
 
-    $ foreman start
+The easiest way to run the app is using `heroku local`. This starts all the processes defined in `Procfile`, including the Rails server.
+
+    $ heroku local
     $ open http://localhost:3000
 
 ## Conventions


### PR DESCRIPTION
The README recommended `foreman start` as the way to run the app, but in practice this does not work: the `release` process in the `Procfile` exits, which causes foreman to shutdown all other processes:

```
13:44:10 release.1 | exited with code 0
13:44:10 system    | sending SIGTERM to all processes
13:44:10 web.1     | - Gracefully stopping, waiting for requests to finish
13:44:10 web.1     | === puma shutdown: 2017-11-27 13:44:10 -0800 ===
13:44:10 web.1     | - Goodbye!
13:44:10 web.1     | terminated by SIGTERM
```

A workaround is to ignore the release process, like this:

```
foreman start -m all=1,release=0
```

But there is an even easier solution, which is to use `heroku local`. This is essentially a wrapper of `node-foreman` that automatically ignores the `release` process.

This commit removes the `foreman` gem and updates the README to explain that `heroku local` is the suggested way to run the app locally.