### PR TITLE
Remove extraneous erb syntax

### DIFF
--- a/lib/templates/slim/scaffold/edit.html.slim
+++ b/lib/templates/slim/scaffold/edit.html.slim
@@ -1,4 +1,4 @@
 .page-header
   h1 Editing <%= singular_table_name %>
 
-== render 'form', <%= singular_table_name %>: @<%= singular_table_name %> %>
+== render 'form', <%= singular_table_name %>: @<%= singular_table_name %>

--- a/lib/templates/slim/scaffold/new.html.slim
+++ b/lib/templates/slim/scaffold/new.html.slim
@@ -1,4 +1,4 @@
 .page-header
   h1 Create <%= singular_table_name %>
 
-== render 'form', <%= singular_table_name %>: @<%= singular_table_name %> %>
+== render 'form', <%= singular_table_name %>: @<%= singular_table_name %>


### PR DESCRIPTION
These templates were generating slim templates ending with `%>`