### PR TITLE
PR template that GitHub will use for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+Problem
+=======
+problem statement, including
+[link to Pivotal Tracker #12345678](https://www.pivotaltracker.com/story/show/12345678)
+
+Solution
+========
+What I/we did to solve this problem
+
+with @pairperson1
+
+Change summary:
+---------------
+* Tidy, well formulated commit message
+* Another great commit message
+* Something else I/we did
+
+Steps to Verify:
+----------------
+1. A setup step / beginning state
+1. What to do next
+1. Any other instructions
+1. Expected behavior
+1. Suggestions for testing
+
+Screenshots (optional):
+-----------------------
+Show-n-tell images/animations here
+


### PR DESCRIPTION
Problem
=======
This format works very well for us in a current project; it encourages/reminds you to do a little more testing, a little tidier commits, to credit your pairing partner, etc.  It's a combination of formats I've used at other companies and with other clients.

(this link doesn't work)
[a link to Pivotal Tracker #12345678](https://www.pivotaltracker.com/story/show/12345678)

Solution
========
Add a PR template.

Change summary:
---------------
* a PR template that GitHub will use for PRs

Steps to Verify:
----------------
1. Won't be able to verify until this goes into master; then the template appears for new PRs.
