### PR TITLE
Drop requirement on postgres db user for test and development envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Generated with [Raygun](https://github.com/carbonfive/raygun).
 To run the specs or fire up the server, be sure you have these installed (and running):
 
 * Ruby 2.5 (see [.ruby-version](.ruby-version)).
-* PostgreSQL 10.3+ (`brew install postgresql`) with superuser 'postgres' with no password (`createuser -s postgres`).
+* PostgreSQL 10.3+ (`brew install postgresql`).
 * Chromedriver 2.3+ for Capybara testing (`brew install chromedriver`).
 * Heroku CLI (`brew install heroku`).
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,4 @@
-# PostgreSQL. Versions 8.2 and up are supported.
-# Use 'createuser -s postgres' to create a general purpose db (super)user.
+# PostgreSQL: versions 9.1 and up are supported.
 
 default: &default
   adapter: postgresql
@@ -10,7 +9,6 @@ default: &default
 development:
   <<: *default
   database: app_prototype_development
-  username: postgres
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
The postgres user was used for a good reason that I've forgotten from years ago. I'm not sure it's necessary anymore.

Can anyone think of a reason why it's better to have a hardcoded and consistent postgresql username, rather than the default of using your local account?

Interestingly, one reason might be because CircleCI hardcodes the pg username in it's configuration. Though, it still seems to work (we have a green build).