### PR TITLE
Chores/updates for chromedriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ end
 group :test do
   gem "capybara"
   # gem "capybara-email"
-  gem "capybara-selenium"
+  gem "chromedriver-helper"
+  gem "selenium-webdriver"
   gem "simplecov"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
     annotate (2.7.4)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (8.6.5)
@@ -72,11 +74,11 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
-    capybara-selenium (0.0.6)
-      capybara
-      selenium-webdriver
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (2.1.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -106,6 +108,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
@@ -207,7 +210,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -229,9 +232,9 @@ GEM
       sprockets (> 2.11)
       sprockets-rails
       tilt
-    selenium-webdriver (3.13.0)
+    selenium-webdriver (3.14.1)
       childprocess (~> 0.5)
-      rubyzip (~> 1.2)
+      rubyzip (~> 1.2, >= 1.2.2)
     simple_form (4.0.1)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -288,7 +291,7 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 4.1.1)
   capybara
-  capybara-selenium
+  chromedriver-helper
   coffee-rails
   dotenv-rails
   factory_bot_rails
@@ -305,6 +308,7 @@ DEPENDENCIES
   rubocop
   sass-rails
   sassc-rails
+  selenium-webdriver
   simple_form
   simplecov
   slim-rails

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ To run the specs or fire up the server, be sure you have these installed (and ru
 
 * Ruby 2.5 (see [.ruby-version](.ruby-version)).
 * PostgreSQL 10.3+ (`brew install postgresql`).
-* Chromedriver 2.3+ for Capybara testing (`brew install chromedriver`).
 * Heroku CLI (`brew install heroku`).
 
 ### First Time Setup
@@ -87,6 +86,26 @@ Guard is configured to run ruby specs, and also listen for livereload connection
     $ open http://localhost:1080/
 
 Learn more at [mailcatcher.me](http://mailcatcher.me/). And please don't add mailcatcher to the Gemfile.
+
+### Using ChromeDriver 
+
+The ChromeDriver version used in this project is maintained by the [chromedriver-helper](https://github.com/flavorjones/chromedriver-helper) gem.  This is means that the
+feature specs are not running against the ChromeDriver installed previously on the machine, such as by Homebrew.
+
+If you encounter issues related to the chromedriver version, e.g
+
+
+    Selenium::WebDriver::Error::UnknownError:
+      unknown error: call function result missing 'value'
+        (Session info: headless chrome=69.0.3497.100)
+        (Driver info: chromedriver=2.34.522932 (4140ab217e1ca1bec0c4b4d1b148f3361eb3a03e),platform=Mac OS X 10.13.6 x86_64)
+
+
+you can update to the latest with executables from `chromedriver-helper`:
+
+    $ chromedriver-update  # defaults to latest version of Chromedriver
+
+refer to documentation for setting specific versions.
 
 ### Continuous Integration/Deployment with CircleCI and Heroku
 

--- a/bin/setup
+++ b/bin/setup
@@ -29,6 +29,9 @@ chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
+  puts "\n== Updating chromedriver to latest version =="
+  system! "chromedriver-update"
+
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
 end

--- a/bin/update
+++ b/bin/update
@@ -28,6 +28,9 @@ chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
+  puts "\n== Updating chromedriver to latest version =="
+  system! "chromedriver-update"
+
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
 end


### PR DESCRIPTION
Problem
=======
Newly generated Rails projects now come with `chromedriver-helper` in its Gemfile.  This gem manages the chromedriver version to be used by the Selenium Webdriver.

We want to include this gem in this project, and also retrieve the lastest chromedriver in our `setup` and `update` scripts.

Change summary:
---------------
* Include `chromedriver-helper` in Gemfile.
* Replace `capybara-selenium` gem with `selenium-webdriver` since we already have the `capybara` gem.
* Update `bin/setup` and `bin/update` scripts with `chromedriver-update`
* Update README with `chromedriver-helper` info.

