### PR TITLE
Convert CircleCI config to use workflows; add bundler-audit job that runs on master/development branch only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,4 +87,9 @@ workflows:
   build_and_audit:
     jobs:
       - build
-      - audit
+      - audit:
+          filters:
+            branches:
+              only:
+                - development
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,17 @@
 version: 2
 jobs:
+  audit:
+    working_directory: ~/app-prototype
+    docker:
+      - image: circleci/ruby:2.5.3
+    steps:
+      - checkout
+      - run:
+          name: Install bundler-audit
+          command: gem install bundler-audit
+      - run:
+          name: Check for vulnerable gem versions
+          command: bundle-audit check --update
   build:
     parallelism: 1
     working_directory: ~/app-prototype
@@ -69,3 +81,10 @@ jobs:
       # Save screenshots for debugging
       - store_artifacts:
           path: ./tmp/screenshots
+
+workflows:
+  version: 2
+  build_and_audit:
+    jobs:
+      - build
+      - audit


### PR DESCRIPTION
Running `bundler-audit` is a good security practice. This PR adds it to our recommended CircleCI config.

But dealing with security updates reported by bundler-audit in the middle of feature development can be distracting, especially when the same gem has to be updated in every branch. It's better to update the gem once, merge that into master, and then all the other features will benefit once they are later merged into master as well.

Converting the CircleCI to workflows allows this flexibility of defining multiple jobs, and filtering which jobs are run on which branches. Using that we can skip running `bundler-audit` on feature branches, but still run it on `master`.