### PR TITLE
Specify bundle config via ENV; various cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ jobs:
     docker:
       - image: circleci/ruby:2.5.3-node-browsers
         environment:
+          BUNDLE_JOBS: 4
+          BUNDLE_PATH: vendor/bundle
           PGHOST: 127.0.0.1
           PGUSER: postgres
           RAILS_ENV: test
@@ -22,16 +24,20 @@ jobs:
           keys:
             - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
             - gem-cache-{{ arch }}-{{ .Branch }}
-            - gem-cache
+            - gem-cache-{{ arch }}-
 
       # Bundle install dependencies and remove any unused gems
-      - run: bundle install --path ./vendor/bundle --jobs=4 && bundle clean --force
+      - run:
+          name: bundle install
+          command: |
+            bundle check || bundle install
+            bundle clean
 
       # Store bundle cache
       - save_cache:
           key: gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
-            - ./vendor/bundle
+            - vendor/bundle
 
       # Rubocop compliance
       - run: bundle exec rubocop


### PR DESCRIPTION
This commit changes the bundler-related steps that we use in Circle CI to bring them up to speed with practices we have in other C5 projects.

First, add a `bundle check` step to speed things up. For large Gemfiles with many sources, `bundle install` can lag a few seconds even if there is nothing to install. Whereas `bundle check` is much faster and can eliminate the need to run `bundle install` in many cases.

Note that both `check` and `install` require a `--path` option. Rather than repeat this, specify it once via the `BUNDLE_PATH` environment variable. For consistency, specify `BUNDLE_JOBS` there as well.

Also, the `--force` option is only needed when gems are installed globally (i.e. no path option is specified). Since we are using a path, `--force` does nothing and can be removed.

Finally, the Circle CI documentation recommends that `{{ arch }}` always be included in the cache key, even for fallbacks. Add it.