### PR TITLE
Substitute chromedriver-helper for webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ end
 group :test do
   gem "capybara"
   # gem "capybara-email"
-  gem "chromedriver-helper"
   gem "selenium-webdriver"
   gem "simplecov"
+  gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,6 @@ GEM
     annotate (2.7.4)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.5.0)
@@ -77,9 +75,6 @@ GEM
       xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -109,7 +104,6 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.2)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
@@ -135,6 +129,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.9)
+    net_http_ssl_fix (0.0.10)
     nio4r (2.3.1)
     nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
@@ -274,6 +269,11 @@ GEM
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.5.0)
+    webdrivers (3.7.1)
+      net_http_ssl_fix
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -292,7 +292,6 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 4.3.1)
   capybara
-  chromedriver-helper
   coffee-rails
   dotenv-rails
   factory_bot_rails
@@ -317,6 +316,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen
   uglifier
+  webdrivers
 
 RUBY VERSION
    ruby 2.6.2p47

--- a/README.md
+++ b/README.md
@@ -89,23 +89,8 @@ Learn more at [mailcatcher.me](http://mailcatcher.me/). And please don't add mai
 
 ### Using ChromeDriver
 
-The ChromeDriver version used in this project is maintained by the [chromedriver-helper](https://github.com/flavorjones/chromedriver-helper) gem.  This is means that the
+The ChromeDriver version used in this project is maintained by the [webdrivers](https://github.com/titusfortner/webdrivers) gem.  This is means that the
 feature specs are not running against the ChromeDriver installed previously on the machine, such as by Homebrew.
-
-If you encounter issues related to the chromedriver version, e.g
-
-
-    Selenium::WebDriver::Error::UnknownError:
-      unknown error: call function result missing 'value'
-        (Session info: headless chrome=69.0.3497.100)
-        (Driver info: chromedriver=2.34.522932 (4140ab217e1ca1bec0c4b4d1b148f3361eb3a03e),platform=Mac OS X 10.13.6 x86_64)
-
-
-you can update to the latest with executables from `chromedriver-helper`:
-
-    $ chromedriver-update  # defaults to latest version of Chromedriver
-
-refer to documentation for setting specific versions.
 
 ### Headed vs headless Chrome
 

--- a/bin/setup
+++ b/bin/setup
@@ -29,9 +29,6 @@ chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
-  puts "\n== Updating chromedriver to latest version =="
-  system! "chromedriver-update"
-
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
 end

--- a/bin/update
+++ b/bin/update
@@ -28,9 +28,6 @@ chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
-  puts "\n== Updating chromedriver to latest version =="
-  system! "chromedriver-update"
-
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
 end


### PR DESCRIPTION
Problem
=======
`chromedriver-helper` is sunsetting at the end of the month.

Solution
========
The official recommendation is to use the `webdrivers`. This will become the default in Rails 6 as well.