### PR TITLE
Drop coffee-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "rails", "~> 5.2.3"
 # Front-endy
 gem "autoprefixer-rails"
 gem "bootstrap", "~> 4.3.1"
-gem "coffee-rails"
 gem "jquery-rails"
 gem "sass-rails", require: false # Only needed for generator (e.g. rail g controller Users)
 gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,13 +76,6 @@ GEM
     childprocess (1.0.1)
       rake (< 13.0)
     coderay (1.1.2)
-    coffee-rails (5.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 5.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     debug_inspector (0.0.3)
@@ -290,7 +283,6 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 4.3.1)
   capybara
-  coffee-rails
   dotenv-rails
   factory_bot_rails
   jquery-rails


### PR DESCRIPTION
Problem
=======
Coffeescript has fallen out of fashion, at C5 and in general. If someone wants to use it, then can re-add the gem.

Solution
========
Drop the gem from the gemfile.