### PR TITLE
Tweak headless chrome configuration to restore headless behavior

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,10 +7,12 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  options = { "args" => %w[headless window-size=1024,3840] }
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << "--headless"
+  browser_options.args << "--window-size=1024,3840"
 
   # Try this if chrome crashes. https://sites.google.com/a/chromium.org/chromedriver/help/chrome-doesn-t-start
-  # options["args"] << "no-sandbox"
+  # browser_options.args << "--no-sandbox"
 
   # This enables access to the JS console logs in your feature specs.
   # You can see the logs during the test by calling (for example):
@@ -18,16 +20,14 @@ Capybara.register_driver :headless_chrome do |app|
   #   puts page.driver.browser.manage.logs.get(:browser).map(&:inspect).join("\n")
   #
   # This will print out each log entry in the JS log, including e.g. the React welcome notice.
-  logging_prefs = { "browser" => "ALL" }
-
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chrome_options: options,
-    logging_prefs: logging_prefs
+    logging_prefs: { "browser" => "ALL" }
   )
 
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
+    options: browser_options,
     desired_capabilities: capabilities
   )
 end


### PR DESCRIPTION
Headless mode stopped working for some reason sometime over the last couple of months. Feature specs would pass, but they would open a headed chrome instance instead.

Tweaking how we tell chrome to be headless appears to make it work again.