### PR TITLE
Support latest rubocop-* gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
 inherit_from:
   - https://raw.githubusercontent.com/carbonfive/c5-conventions/master/rubocop/rubocop.yml
 
+require:
+  - rubocop-performance
+  - rubocop-rails
+
 Rails:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem "rspec_junit_formatter"
   gem "rubocop", require: false
   gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,15 +204,18 @@ GEM
     rspec-support (3.8.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.72.0)
+    rubocop (0.73.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-performance (1.4.0)
+    rubocop-performance (1.4.1)
       rubocop (>= 0.71.0)
+    rubocop-rails (2.2.1)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
@@ -302,6 +305,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   rubocop-performance
+  rubocop-rails
   sassc-rails
   selenium-webdriver
   simple_form


### PR DESCRIPTION
Rubocop has been updated, and some functionality split in to a new gem.

1. Add the rubocop-rails gem
2. Upgrade to the latest rubocop, rubocop-rails, rubocop-performance gems.

This resolves the issue where rubocop reports several warnings about unknown cops.

There's an open question about whether or not https://github.com/carbonfive/c5-conventions/blob/master/rubocop/rubocop.yml should include rails specific cops, because some non-rails ruby projects use those conventions. I'd like to address that as a separate conversation though.