### PR TITLE
Ensure tmp/pids dir exists so puma doesn't crash

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -28,7 +28,7 @@ FileUtils.chdir APP_ROOT do
   system! "bin/rails db:sample_data"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! "bin/rails log:clear tmp:clear"
+  system! "bin/rails log:clear tmp:clear tmp:create"
 
   puts "\n== Restarting application server =="
   system! "bin/rails restart"


### PR DESCRIPTION
Rails 6.0.0 introduced a last-minute change to the default puma configuration. It now requires that a `tmp/pids` directory exists:

https://github.com/carbonfive/raygun-rails/commit/2215879e84c11fbc25bd85bcc66365a0c24caa16#diff-3f0c524806c4374c99a509efaffd3e8aR20

With a clean checkout, there is no such directory. So if you try to run puma directly or if you try to boot the app with `heroku local`, you get:

```
$ heroku local
[OKAY] Loaded ENV .env File as KEY=VALUE Format
9:00:18 AM web.1 |  Puma starting in single mode...
9:00:18 AM web.1 |  * Version 4.1.0 (ruby 2.6.3-p62), codename: Fourth and One
9:00:18 AM web.1 |  * Min threads: 5, max threads: 5
9:00:18 AM web.1 |  * Environment: development
9:00:19 AM web.1 |  * Listening on tcp://0.0.0.0:3000
9:00:19 AM web.1 |  bundler: failed to load command: puma (/Users/mattb/.rbenv/versions/2.6.3/bin/puma)
9:00:19 AM web.1 |  Errno::ENOENT: No such file or directory @ rb_sysopen - tmp/pids/server.pid
9:00:19 AM web.1 |    /Users/mattb/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/puma-4.1.0/lib/puma/launcher.rb:135:in `initialize'
9:00:19 AM web.1 |    /Users/mattb/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/puma-4.1.0/lib/puma/launcher.rb:135:in `open'
9:00:19 AM web.1 |    /Users/mattb/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/puma-4.1.0/lib/puma/launcher.rb:135:in `write_pid'
9:00:19 AM web.1 |    /Users/mattb/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/puma-4.1.0/lib/puma/launcher.rb:108:in `write_state'
9:00:19 AM web.1 |    /Users/mattb/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/puma-4.1.0/lib/puma/single.rb:103:in `run'
9:00:19 AM web.1 |    /Users/mattb/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/puma-4.1.0/lib/puma/launcher.rb:188:in `run'
9:00:19 AM web.1 |    /Users/mattb/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/puma-4.1.0/lib/puma/cli.rb:80:in `run'
9:00:19 AM web.1 |    /Users/mattb/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/puma-4.1.0/bin/puma:10:in `<top (required)>'
9:00:19 AM web.1 |    /Users/mattb/.rbenv/versions/2.6.3/bin/puma:23:in `load'
9:00:19 AM web.1 |    /Users/mattb/.rbenv/versions/2.6.3/bin/puma:23:in `<top (required)>'
[DONE] Killing all processes with signal  SIGINT
9:00:19 AM web.1 Exited with exit code null
```

Interestingly, if you use `rails server`, you do _not_ get this error. That's because internally the server command explicitly creates the `tmp/pids` directory before starting puma:

https://github.com/rails/rails/blob/6b40767df8635125c62b550d2652074d2e6daf03/railties/lib/rails/commands/server/server_command.rb#L35

This commit fixes this problem, allowing `heroku local` to be used, by creating the necessary tmp directories when the project is initially set up, via `bin/setup`.