### PR TITLE
Aggregate Failures: Default to false for feature specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,9 +59,9 @@ RSpec.configure do |config|
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
 
-  # Enable aggregate failures unless explcitly disabled at the spec level.
+  # Enable aggregate failures unless it's a feature spec or explcitly configured at the spec level.
   config.define_derived_metadata do |meta|
-    meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
+    meta[:aggregate_failures] = (meta[:type] != :feature) unless meta.key?(:aggregate_failures)
   end
 
   # These two settings work together to allow you to limit a spec run

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,7 +59,7 @@ RSpec.configure do |config|
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
 
-  # Enable aggregate failures unless it's a feature spec or explcitly configured at the spec level.
+  # Enable aggregate failures unless it's a system spec or explicitly configured at the spec level.
   config.define_derived_metadata(type: proc { |type| type != :system }) do |meta|
     meta[:aggregate_failures] = true
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,8 +60,12 @@ RSpec.configure do |config|
   # with RSpec, but feel free to customize to your heart's content.
 
   # Enable aggregate failures unless it's a feature spec or explcitly configured at the spec level.
-  config.define_derived_metadata do |meta|
-    meta[:aggregate_failures] = (meta[:type] != :feature) unless meta.key?(:aggregate_failures)
+  config.define_derived_metadata(type: proc { |type| type != :system }) do |meta|
+    meta[:aggregate_failures] = true
+  end
+
+  config.define_derived_metadata(type: :system) do |meta|
+    meta[:aggregate_failures] = false unless meta.key?(:aggregate_failures)
   end
 
   # These two settings work together to allow you to limit a spec run


### PR DESCRIPTION
Problem
=======

Aggregate failures (see https://relishapp.com/rspec/rspec-core/docs/expectation-framework-integration/aggregating-failures) is a nice feature, but doesn't work well for specs that are a series of dependent expectations, like those found in feature specs.

For feature specs, rspec will keep on running after a failure, where it is very likely all subsequent expectation will also fail because they were dependent on the first passing in some way. This slows down feature test suites with failures quite a bit.

Solution
========

This PR defaults to aggregate failure for all spec types accept feature specs. 

Also, the individual spec can override aggregate failures using any of the normal techniques for doing so. This only sets a default for when no other configuration is set.