### PR TITLE
Uncomment ActionCable to fix zeitwerk crash

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto
 # reloading.
 
-# module ApplicationCable
-#   class Channel < ActionCable::Channel::Base
-#   end
-# end
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto
 # reloading.
 
-# module ApplicationCable
-#   class Connection < ActionCable::Connection::Base
-#   end
-# end
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+  end
+end


### PR DESCRIPTION
Problem
=======

Before, if you tried to run a raygun-rails app in production mode, you would get a zeitwerk error like this:

```
$ RAILS_ENV=production bin/rails console
zeitwerk-2.1.10/lib/zeitwerk/loader/callbacks.rb:17:in `on_file_autoloaded': expected file raygun-rails/app/channels/application_cable/connection.rb to define constant ApplicationCable::Connection, but didn't (NameError)
  from zeitwerk-2.1.10/lib/zeitwerk/kernel.rb:17:in `block in require'
```

This is because the contents of `channel.rb` and `connection.rb` were commented out. In Rails 6.0, the autoloading library (i.e. the zeitwerk gem) enforces that all autoloaded `.rb` files must conform to class/module naming conventions.

Solution
========

Fix by uncommenting the contents of these files, which puts us back into parity with `rails new`.
