### PR TITLE
Explicitly list the Rails frameworks to load

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,18 @@
 require_relative "boot"
 
-require "rails/all"
+# Pick the frameworks you want:
+require "action_cable/engine"
+require "action_controller/railtie"
+require "action_mailbox/engine"
+require "action_mailer/railtie"
+require "action_text/engine"
+require "action_view/railtie"
+require "active_job/railtie"
+require "active_model/railtie"
+require "active_record/railtie"
+require "active_storage/engine"
+# require "rails/test_unit/railtie"
+require "sprockets/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
Problem
=======

Almost no app generated from raygun-rails will use the entire suite of frameworks that are bundled with Rails. It was not obvious how to opt out of the ones that are not needed.

Solution
========

This commit replaces `"rails/all"` with the explicit list of frameworks that make up Rails 6.0, so that a developer can easily delete or comment out the ones they do not wish to use. In our case we are using RSpec instead of TestUnit, so we can comment out the TestUnit framework.
