### PR TITLE
Fix Rails console warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ end
 group :development, :test do
   gem "factory_bot_rails"
   gem "rspec-rails", "~> 4.0.0.beta2" # For Rails 6 support.
-  gem "rspec_junit_formatter"
+  gem "rspec_junit_formatter", require: false
   gem "rubocop", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false


### PR DESCRIPTION
Problem
=======

Before, when booting the Rails console you would see a warning about `can't alias context from irb_context`:

```
$ bin/rails console
Running via Spring preloader in process 77125
Loading development environment (Rails 6.0.0)
irb: warn: can't alias context from irb_context.
```

Searching for this warning lead me to various GitHub threads about this being caused by rspec in some way, namely that rspec was being loaded too early in the console boot sequence.

Solution
========

In our case, the fix was to defer loading of the `rspec_junit_formatter` (which in turn loads rspec) by marking it as `require: false` in the Gemfile.

Now the console boots without warnings:

```
$ bin/rails console
Running via Spring preloader in process 77930
Loading development environment (Rails 6.0.0)
```
