### PR TITLE
Fix Rails console warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 group :development, :test do
   gem "factory_bot_rails"
   gem "rspec-rails"
-  gem "rspec_junit_formatter"
+  gem "rspec_junit_formatter", require: false
   gem "rubocop", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false


### PR DESCRIPTION
This reapplies my fix from #266 that seems to have gotten clobbered in a merge here: https://github.com/carbonfive/raygun-rails/commit/8a952891dd0ab6383cf6dba1c2b8ed4f54b46f47#diff-8b7db4d5cc4b8f6dc8feb7030baa2478