### PR TITLE
Add Shoulda-Matchers to the skeleton

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :test do
   gem "capybara"
   # gem "capybara-email"
   gem "selenium-webdriver"
+  gem "shoulda-matchers"
   gem "simplecov"
   gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,8 @@ GEM
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    shoulda-matchers (4.1.2)
+      activesupport (>= 4.2.0)
     simple_form (5.0.1)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -284,6 +286,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   selenium-webdriver
+  shoulda-matchers
   simple_form
   simplecov
   slim-rails

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,6 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Shoulda-matchers provide some quick and easy matchers for testing rails
model validations that can save a chunk of work while adding to the
model specs more behavior tests.

For details about what's in the gem:

https://github.com/thoughtbot/shoulda-matchers

This was driven by https://github.com/carbonfive/raygun/issues/125

Changes
-------

* Add shoulda-matchers gem
* add shoulda_matchers initializer for test (`test/support`)
* (not checked in) - add a model with a simple spec to verify the
  installation