### PR TITLE
Rename HOSTNAME env var to CANONICAL_HOSTNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Several common features and operational parameters can be set using environment 
 
 **Optional**
 
-* `HOSTNAME` - Canonical hostname for this application. Other incoming requests will be redirected to this hostname.
+* `CANONICAL_HOSTNAME` - Canonical hostname for this application. Other incoming requests will be redirected to this hostname.
   Also used by mailers to generate full URLs.
 * `FORCE_SSL` - Require SSL for all requests, redirecting if necessary (default: false).
 * `BASIC_AUTH_PASSWORD` - Enable basic auth with this password.

--- a/config.ru
+++ b/config.ru
@@ -3,7 +3,7 @@
 require ::File.expand_path("../config/environment", __FILE__)
 
 # Redirect to the custom (canonical) hostname.
-use Rack::CanonicalHost, ENV["HOSTNAME"] if ENV["HOSTNAME"].present?
+use Rack::CanonicalHost, ENV["CANONICAL_HOSTNAME"] if ENV["CANONICAL_HOSTNAME"].present?
 
 # Optional Basic Auth - Enabled if BASIC_AUTH_PASSWORD is set. User is optional (any value will be accepted).
 BASIC_AUTH_USER     = ENV["BASIC_AUTH_USER"].presence

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
 
   # Set the host so that we can generate full URLs outside the context of a request
   # (e.g. sending email).
-  config.action_mailer.default_url_options = { host: ENV.fetch("HOSTNAME", "app-prototype.herokuapp.com") }
+  config.action_mailer.default_url_options = { host: ENV.fetch("CANONICAL_HOSTNAME", "app-prototype.herokuapp.com") }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
Problem + Solution
=======

`HOSTNAME` has special significance to apps running inside Docker containers. Rename our variable to `CANONICAL_HOSTNAME` so that it does not conflict.

Fixes #322 

Steps to Verify:
----------------
1. Run the app locally with `CANONICAL_HOSTNAME=localhost bin/rails s`.
2. Verify that if you visit <http://127.0.0.1:3000/> you are redirected to <http://localhost:3000/>.