### PR TITLE
Start webpack-dev-server via `yarn start`

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+web:     bin/rails server -b 0.0.0.0
+webpack: bin/webpack-dev-server
+#worker:  bundle exec rake jobs:work

--- a/README.md
+++ b/README.md
@@ -41,18 +41,19 @@ Note: `./bin/rake` runs the springified version of rake (there's a `./bin/rspec`
 
 ### Running the Application Locally
 
-The easiest way to run the app is using `heroku local`. This starts all the processes defined in `Procfile`, including the Rails server.
+The easiest way to run the app is using `yarn start`. This starts all the processes defined in `Procfile.dev`, including the Rails server and the webpack dev server.
 
-    $ heroku local
-    $ open http://localhost:3000
+    $ yarn start
+
+The app will then be accessible at <http://localhost:3000>.
 
 ### Webpack Dev Server
 
 By default, webpacker will compile assets on demand. In other words, you don’t need to precompile all assets ahead of time — webpacker lazily compiles assets it has not served yet. However, you will need to manually reload your browser to see new changes when you edit an asset.
 
-Alternatively, for live code reloading, you can run `./bin/webpack-dev-server` in a separate terminal from `rails s`. Asset requests are proxied to the dev server, and it will automatically refresh your browser when it detects changes to the pack.
+Alternatively, for live code reloading, you can run `./bin/webpack-dev-server` in a separate terminal from `rails s`. This done for you automatically if you use `yarn start` to run the app. Asset requests are proxied to the dev server, and it will automatically refresh your browser when it detects changes to the pack.
 
-When you stop the dev server, Rails automatically reverts back to on-demand compilation.
+If you stop the dev server, Rails automatically reverts back to on-demand compilation.
 
 ## Conventions
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "engines": {
     "node": ">=10"
   },
+  "scripts": {
+    "start": "heroku local -f Procfile.dev"
+  },
   "dependencies": {
     "@rails/actioncable": "^6.0.2",
     "@rails/activestorage": "^6.0.2",


### PR DESCRIPTION
Problem
=======

Running `bin/webpack-dev-server` is a big productivity booster but it is not very discoverable, especially for developers who aren't super-familiar with webpacker. It's also a bit tedious to have to use two separate console tabs just to run the app effectively (i.e. one tab for `rails s`, another for `bin/webpack-dev-server`).

Solution
========

The webpack-dev-server enables automatic recompilation of JS and SCSS files and refreshing of the browser. This means that when you edit e.g. a `.jsx` file, you don't have to hit reload in the browser; the changes will just magically appear.

The README previously suggested to run `bin/webpack-dev-server` in a separate terminal session. This commit simplifies this by introducing a `Procfile.dev` that starts both the Rails server and the webpack dev server. The `yarn start` shortcut now does this:

    heroku local -f Procfile.dev

This makes it much quicker for a developer to get the app up and running in a single terminal session with the live reload behavior for webpack.

Here's an example from another project where I've set this up:

```
$ yarn start
yarn run v1.22.0
$ heroku local -f Procfile.dev
[OKAY] Loaded ENV .env File as KEY=VALUE Format
9:48:35 AM web.1     |  Puma starting in single mode...
9:48:35 AM web.1     |  * Version 4.3.1 (ruby 2.6.5-p114), codename: Mysterious Traveller
9:48:35 AM web.1     |  * Min threads: 5, max threads: 5
9:48:35 AM web.1     |  * Environment: development
9:48:36 AM webpack.1 |  ℹ ｢wds｣: Project is running at http://localhost:3035/
9:48:36 AM webpack.1 |  ℹ ｢wds｣: webpack output is served from /packs/
9:48:36 AM webpack.1 |  ℹ ｢wds｣: Content not from webpack is served from public/packs
9:48:36 AM webpack.1 |  ℹ ｢wds｣: 404s will fallback to /index.html
9:48:37 AM webpack.1 |  Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
9:48:41 AM web.1     |  * Listening on tcp://0.0.0.0:3000
9:48:41 AM web.1     |  Use Ctrl-C to stop
9:48:41 AM webpack.1 |  ℹ ｢wdm｣: Hash: 5a1462a62fb5a8cabe18
9:48:41 AM webpack.1 |  Version: webpack 4.41.2
9:48:41 AM webpack.1 |  Time: 4961ms
9:48:41 AM webpack.1 |  Built at: 02/25/2020 9:48:41 AM
9:48:41 AM webpack.1 |                                       Asset       Size       Chunks                         Chunk Names
9:48:41 AM webpack.1 |      js/application-5cad5c771b4c5e6d0391.js   3.03 MiB  application  [emitted] [immutable]  application
9:48:41 AM webpack.1 |  js/application-5cad5c771b4c5e6d0391.js.map   3.15 MiB  application  [emitted] [dev]        application
9:48:41 AM webpack.1 |                               manifest.json  364 bytes               [emitted]              
9:48:41 AM webpack.1 |  ℹ ｢wdm｣: Compiled successfully.
```

And touching a `.jsx` automatically triggers:

```
9:50:53 AM webpack.1 |  ℹ ｢wdm｣: Compiling...
9:50:54 AM webpack.1 |  ℹ ｢wdm｣: Hash: 17613bb719e70c4e9aa0
9:50:54 AM webpack.1 |  Version: webpack 4.41.2
9:50:54 AM webpack.1 |  Time: 485ms
9:50:54 AM webpack.1 |  Built at: 02/25/2020 9:50:54 AM
9:50:54 AM webpack.1 |                                       Asset       Size       Chunks                         Chunk Names
9:50:54 AM webpack.1 |      js/application-1ab7d696bf7d1b50cfb1.js   3.03 MiB  application  [emitted] [immutable]  application
9:50:54 AM webpack.1 |  js/application-1ab7d696bf7d1b50cfb1.js.map   3.15 MiB  application  [emitted] [dev]        application
9:50:54 AM webpack.1 |                               manifest.json  364 bytes               [emitted]              
9:50:54 AM webpack.1 |  ℹ ｢wdm｣: Compiled successfully.
```