### PR TITLE
Ensure db:setup and db:sample_data are run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,6 @@ commands:
       - run:
           name: Set up database
           command: bundle exec rake db:setup
-      # Ensure sample_data runs without issues (note: data is loaded into the development database)
-      - run:
-          name: Seed with sample data
-          command: bundle exec rake db:sample_data
   rspec:
     description: Run RSpec tests
     steps:
@@ -102,14 +98,20 @@ jobs:
       - checkout
       - bundle-install
       - yarn-install
+      - db-setup
       # Rubocop compliance
       - run: bundle exec rubocop
+      # Ensure sample_data runs without issues
+      - run:
+          name: Seed with sample data
+          command: bundle exec rake db:sample_data
   rspec:
     executor: rails
     steps:
       - checkout
       - bundle-install
       - yarn-install
+      - db-setup
       - rspec
 
 workflows:


### PR DESCRIPTION
Before, we had a `db-setup` command defined in our CircleCI config but we were never actually calling it anywhere. The `db-setup` command did two things: 1) `rake db:setup` and 2) `rake db:sample_data`. The reason that our specs still passed in spite of this is because Rails automatically "prepares" the database when you run `rspec` before the specs run, so the database was getting created by Rails anyway. But our `db:sample_data` was never getting tested.

Fix by doing two things:

First, explicitly call `db:sample_data` within the `static_analysis` job so that it actually gets tested. There was a note that "data is loaded into the development database"; this is not true, so I removed the note. There is only one database defined in our CircleCI config (`app_prototype_test`) and we are explicitly setting `RAILS_ENV=test`, so the sample data will definitely get inserted into the test database (I verified this using SSH into the Circle container). It is safe to "pollute" the test database inside the `static_analysis` job because no other steps within this job depend on the data in the test database. Each job gets its own postgres container so there is no risk of data from `static_analysis` polluting other jobs.

Second, explicitly call the `db-setup` command in each job that relies on the database (`rspec` and `static_analysis`). This ensures that the database has the schema loaded before the steps that rely on the db are run. We had relied on Rails magic do this before, but this is more explicit.
