### PR TITLE
Circle CI: Improve cache keys and fallbacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,18 +20,17 @@ commands:
     description: Install Ruby gems
     steps:
       - restore_cache:
-          keys: # Include fallbacks to increase the likeliness of a cache hit
-            - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-{{ arch }}-{{ .Branch }}
-            - gem-cache-{{ arch }}-
+          keys:
+            - bundler-cache-v0-{{ arch }}-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
+            - bundler-cache-v0-{{ arch }}-{{ checksum ".ruby-version" }}
       - run:
-          name: Install gems and remove unused gems
+          name: Install new gems and remove unused gems
           command: |
             gem install bundler
             bundle check || bundle install
             bundle clean --force
       - save_cache:
-          key: gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: bundler-cache-v0-{{ arch }}-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
   yarn-install:
@@ -39,15 +38,14 @@ commands:
     steps:
       - restore_cache:
           name: Restore Yarn cache
-          keys: # Include fallbacks to increase the likeliness of a cache hit
-            - yarn-cache-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - yarn-cache-{{ arch }}-{{ .Branch }}
-            - yarn-cache-{{ arch }}-
+          keys:
+            - yarn-cache-v0-{{ arch }}-{{ checksum "yarn.lock" }}
+            - yarn-cache-v0-{{ arch }}
       - run:
-          name: Install JS dependencies
+          name: Yarn install
           command: yarn install --cache-folder .yarn-cache
       - save_cache:
-          key: yarn-cache-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: yarn-cache-v0-{{ arch }}-{{ checksum "yarn.lock" }}
           paths:
             - .yarn-cache
   db-setup:


### PR DESCRIPTION
Problem
=======
The current cache keys, under some circumstances, could lead to multiple sets of gems being cached, which in turn bloats the cache file significantly. We've seen cache files approach 2 gigs, which then would add 30-50 seconds per job in a workflow.

Solution
========
1. Add a `v0` element to the cache key to facilitate easy cache busting, in the event it's necessary. To bust the cache, just increment this to `v1` (or whatever is next).

2. Include `{{ checksum ".ruby-version" }}` to the cache key so that we have a reasonable fallback that gets busted whenever the ruby version changes. This fallback is better than a scorched earth approach, because as along as we're not changing the ruby version, we'll have a pretty solid cache to build up from when the Gemfile.lock changes. It also ensures that we don't end up with duplicate gems (e.g. one set under 2.6.0 and another under 2.7.0).

3. Remove the branch cache key. There's not real evidence that it's useful, and it complicates things unnecessary, IMHO.

Discussed with @eskfung and @mattbrictson .
