### PR TITLE
Switch from awesome_print to amazing_print

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Heroku uses the ruby version to configure your application"s runtime.
 ruby "2.6.6"
 
-gem "awesome_print"
+gem "amazing_print"
 gem "bootsnap", require: false
 gem "pg"
 gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,11 +58,11 @@ GEM
       zeitwerk (~> 2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    amazing_print (1.1.0)
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.0)
-    awesome_print (1.8.0)
     better_errors (2.7.0)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -297,8 +297,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  amazing_print
   annotate
-  awesome_print
   better_errors
   binding_of_caller
   bootsnap


### PR DESCRIPTION
The `awesome_print` gem has gone dormant and the community has forked and renamed it to `amazing_print`. The fork fixes things like Ruby 2.7 compatibility that were not getting addressed in the original project.

Other than the name change this is a drop-in replacement.

https://github.com/amazing-print/amazing_print