### PR TITLE
Add rubocop-rspec and inherit new c5-conventions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,10 @@
 inherit_from:
-  - https://raw.githubusercontent.com/carbonfive/c5-conventions/master/rubocop/rubocop.yml
+  - https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop-common.yml
+  - https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop-performance.yml
+  - https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop-rails.yml
+  - https://raw.githubusercontent.com/carbonfive/c5-conventions/main/rubocop/.rubocop-rspec.yml
 
 require:
   - rubocop-performance
   - rubocop-rails
-
-Rails:
-  Enabled: true
+  - rubocop-rspec

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :development, :test do
   gem "rubocop", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
+  gem "rubocop-rspec", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,8 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
+    rubocop-rspec (1.43.2)
+      rubocop (~> 0.87)
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
     selenium-webdriver (3.142.7)
@@ -323,6 +325,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rails
+  rubocop-rspec
   selenium-webdriver
   shoulda-matchers
   simple_form


### PR DESCRIPTION
## Problem

We'd like to add rubocop-rspec to our projects going forward. The c5-conventions has a [recommended config](https://github.com/carbonfive/c5-conventions/blob/main/rubocop/.rubocop-rspec.yml) for rubocop-rspec that we can opt into.

## Solution

Inherit the rubocop-rspec conventions, along with all the other latest conventions, from the new `main` branch of the c5-conventions repo.

Add `rubocop-rpsec` to the Gemfile.
