### PR TITLE
Remove Heroku CLI requirement for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ To run the specs or fire up the server, be sure you have these installed (and ru
 * Ruby 2.7 (see [.ruby-version](.ruby-version)).
 * Node 12 (see [.node-version](.node-version)).
 * Yarn 1.x (`npm install -g yarn`).
-* Heroku CLI (`brew install heroku`).
 * PostgreSQL 11.2+. (`brew install postgresql`).
+
+To manage deployments you will need:
+
+* Heroku CLI (`brew install heroku`).
 
 It is strongly recommended that you use a version manager like [rbenv](https://github.com/rbenv/rbenv) (for Ruby), [nvm](https://github.com/nvm-sh/nvm) or [nodenv](https://github.com/nodenv/nodenv) (for Node), or [asdf](https://asdf-vm.com/) (for both) to ensure the correct Ruby and Node versions.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=12"
   },
   "scripts": {
-    "start": "heroku local -f Procfile.dev"
+    "start": "nf start -j Procfile.dev"
   },
   "dependencies": {
     "@rails/actioncable": "^6.0.3",
@@ -17,6 +17,7 @@
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
+    "foreman": "^3.0.1",
     "webpack-dev-server": "^3.11.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,7 +2064,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+commander@^2.15.1, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3139,6 +3139,16 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+foreman@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/foreman/-/foreman-3.0.1.tgz#805f28afc5a4bbaf08dbb1f5018c557dcbb8a410"
+  integrity sha512-ek/qoM0vVKpxzkBUQN9k4Fs7l0XsHv4bqxuEW6oqIS4s0ouYKsQ19YjBzUJKTFRumFiSpUv7jySkrI6lfbhjlw==
+  dependencies:
+    commander "^2.15.1"
+    http-proxy "^1.17.0"
+    mustache "^2.2.1"
+    shell-quote "^1.6.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -4660,6 +4670,11 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+mustache@^2.2.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
+  integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
 
 nan@^2.12.1, nan@^2.13.2:
   version "2.14.0"
@@ -6639,6 +6654,11 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shell-quote@^1.6.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
+  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
Problem + Solution
==============

Using the Heroku CLI to start the app locally is a pretty heavy requirement. It would be great if raygun projects were a little more portable so that you can run the app locally without using Heroku.

These days, the Heroku CLI is written in Typescript and delegates to the `foreman` node package behind the scenes for its `heroku local` command. So we can slim down the requirements for running this project quite significantly and make it platform agnostic by using foreman directly.

I left the Heroku CLI requirement listed in the README because other parts of the project do still assume a Heroku-based deployment, like the database export scripts in `bin/`. These would be easy to remove for projects that decide to switch from Heroku to a different platform for deployment. The start script for running locally is a bit trickier to replace, which is why I think it is worth making it more generic. Hence this PR.
