### PR TITLE
Ensure JS error check runs for system specs

### DIFF
--- a/spec/support/raise_on_js_errors.rb
+++ b/spec/support/raise_on_js_errors.rb
@@ -5,7 +5,7 @@ JavaScriptError = Class.new(StandardError)
 # back-end servers often use them to indicate statuses such as form validation
 # errors, which may well be the intended effect of a test.
 RSpec.configure do |config|
-  config.after(type: :feature, js: true) do
+  config.after(type: :system, js: true) do
     js_console_output = page.driver.browser.manage.logs.get(:browser)
     http_4xx_error_detector = /the server responded with a status of 4/
     js_errors = js_console_output.select do |log_item|


### PR DESCRIPTION
Problem+Solution
=============

We classify our capybara specs as "system" specs, to match Rails 6 conventions. However the raise-on-JS-error behavior was configured to run on "feature" specs. So it wasn't in fact doing anything. Fix by changing `:feature` to `:system`.
