### PR TITLE
Drop mailcatcher support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,6 @@ Run `guard` to automatically listen for file changes and run the appropriate spe
 
     $ bundle exec guard
 
-### Using Mailcatcher
-
-    $ gem install mailcatcher
-    $ mailcatcher
-    $ open http://localhost:1080/
-
-Learn more at [mailcatcher.me](http://mailcatcher.me/). And please don't add mailcatcher to the Gemfile.
-
 ### Using ChromeDriver
 
 The ChromeDriver version used in this project is maintained by the [webdrivers](https://github.com/titusfortner/webdrivers) gem.  This is means that the

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,20 +33,8 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # An opinionated ActionMailer config for development:
-  #   - If mailcatcher is running when the app boots, use it.
-  #   - If not, use Rails' built-in :test delivery-method.
-  #   - In either case, always raise delivery errors.
-  #   - Other configuration here follows standard Rails conventions.
-  begin
-    mailcatcher_port = 1025
-    sock = TCPSocket.new("localhost", mailcatcher_port)
-    sock.close
-    config.action_mailer.delivery_method = :smtp
-    config.action_mailer.smtp_settings = { address: "localhost", port: mailcatcher_port }
-  rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL
-    config.action_mailer.delivery_method = :test
-  end
+  # Don't care if the mailer can't send.
+  config.action_mailer.delivery_method = :test
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: "localhost:3000" }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
+  # Default to the :test mailer and raise errors.
   config.action_mailer.delivery_method = :test
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
Problem
=======
Raygun includes a snippet of configuration that makes it easy to use mailcatcher, a lightweight mail server useful during development. The usefulness of his is debatable. It's an old recipe from many years ago. Does anyone use it?

Solution
========
Removed the configuration snippet that is mailcatcher specific, as well as references in the README.

**MERGE AFTER #468.**

Discussion
========

Should we keep it?

Our default settings are still slight deviations from those of a new Rails 6.1 app. I think they make sense, but they're legacy. What do other folks think?