### PR TITLE
Update RSpec configuration and details

### DIFF
--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe PagesController do
+RSpec.describe PagesController do
   describe "GET 'root'" do
     it "returns http success" do
       get "root"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,12 +1,13 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
 
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 
-require "spec_helper"
 require "rspec/rails"
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -16,18 +17,34 @@ require "rspec/rails"
 # run twice. It is recommended that you do not name files matching this glob to
 # end with _spec.rb. You can configure this pattern with the --pattern
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-
+#
+# The following line is provided for convenience purposes. It has the downside
+# of increasing the boot-up time by auto-requiring all files in the support
+# directory. Alternatively, in the individual `*_spec.rb` files, manually
+# require only the support files necessary.
+#
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
-# Checks for pending migrations before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.maintain_test_schema!
+# Checks for pending migrations and applies them before tests are run.
+# If you are not using ActiveRecord, you can remove these lines.
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, remove the following line or assign false
+  # instead of true.
   config.use_transactional_fixtures = true
+
+  # You can uncomment this line to turn off ActiveRecord support entirely.
+  # config.use_active_record = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -36,7 +53,7 @@ RSpec.configure do |config|
   # You can disable this behaviour by removing the line below, and instead
   # explicitly tag your specs with their type, e.g.:
   #
-  #     RSpec.describe UsersController, :type => :controller do
+  #     RSpec.describe UsersController, type: :controller do
   #       # ...
   #     end
   #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,9 +28,6 @@ end
 # the additional setup, and require it from the spec files that actually need
 # it.
 #
-# The `.rspec` file also contains a few flags that are not defaults but that
-# users commonly want.
-#
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -56,10 +53,15 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  # The settings below are suggested to provide a good initial experience
-  # with RSpec, but feel free to customize to your heart's content.
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
 
-  # Enable aggregate failures unless it's a system spec or explicitly configured at the spec level.
+  # Enable aggregate failures unless it's a system spec or explicitly
+  # configured at the spec level.
   config.define_derived_metadata(type: proc { |type| type != :system }) do |meta|
     meta[:aggregate_failures] = true
   end
@@ -68,12 +70,12 @@ RSpec.configure do |config|
     meta[:aggregate_failures] = false unless meta.key?(:aggregate_failures)
   end
 
-  # These two settings work together to allow you to limit a spec run
-  # to individual examples or groups you care about by tagging them with
-  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
-  # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
@@ -85,11 +87,7 @@ RSpec.configure do |config|
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  # config.disable_monkey_patching!
-
-  # This setting enables warnings. It's recommended, but in some cases may
-  # be too noisy due to issues in dependencies.
-  # config.warnings = true
+  config.disable_monkey_patching!
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
@@ -106,12 +104,6 @@ RSpec.configure do |config|
   # particularly slow.
   # config.profile_examples = 10
 
-  # Run non-feature specs (shuffled) before feature specs.
-  # config.register_ordering(:global) do |items|
-  #   features, others = items.partition { |g| g.metadata[:type] == :feature }
-  #   others.shuffle + features.
-  # end
-
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
@@ -123,4 +115,10 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  # Run non-system specs (shuffled) before system specs.
+  config.register_ordering(:global) do |items|
+    systems, others = items.partition { |g| g.metadata[:type] == :system }
+    others.shuffle + systems.shuffle
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -119,6 +119,6 @@ RSpec.configure do |config|
   # Run non-system specs before system specs. `--seed` still applies to ordering both sets.
   config.register_ordering(:global) do |items|
     systems, others = items.partition { |g| g.metadata[:type] == :system }
-    others.shuffle + systems.shuffle
+    others + systems
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,7 +116,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-  # Run non-system specs (shuffled) before system specs.
+  # Run non-system specs before system specs. `--seed` still applies to ordering both sets.
   config.register_ordering(:global) do |items|
     systems, others = items.partition { |g| g.metadata[:type] == :system }
     others.shuffle + systems.shuffle

--- a/spec/system/pages_spec.rb
+++ b/spec/system/pages_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Static Pages" do
+RSpec.describe "Static Pages" do
   # Here's a placeholder feature spec to use as an example, uses the default driver.
   it "/ should include the application name in its title" do
     visit root_path


### PR DESCRIPTION
Problem
=======
Raygun Rails includes configuration for RSpec that is based on a fairly old version of the defaults.

Solution
========
I generated a new set of default configuration and weaved our enhancements in to the new configuration.

* Require rspec configuration files from spec/support.*
* Turn on aggregate failures for non-system specs
* Run non-system specs first, then system specs