### PR TITLE
Enable time helpers from ActiveSupport for specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Enable time helpers like `travel_to` and `freeze_time` to be used within specs
+  # https://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
Problem+Solution
=======

In almost every project we need to freeze time when writing certain tests. Previously we would turn to the `timecop` gem for this, but something similar is now built into Rails. We just need to enable it by including the relevant module.
