### PR TITLE
Add common editor metadata to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ yarn-debug.log*
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
+# Ignore editor metadata.
+.idea/
+.DS_Store
+*~


### PR DESCRIPTION
Problem+Solution
=======
We can guard against common editor and OS metadata files getting checked into our projects by accident by being a little more defensive in our gitignore.
