### PR TITLE
Adopt latest puma best practices from Rails repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Several common features and operational parameters can be set using environment 
 * `RAILS_MAX_THREADS` - Threads per worker (default: 5).
 * `RAILS_MIN_THREADS` - Threads per worker (default: 5).
 * `RAILS_SERVE_STATIC_FILES` - Serve static assets, good for Heroku (default: false).
-* `WEB_CONCURRENCY` - Number of puma workers to spawn (default: 1).
+* `WEB_CONCURRENCY` - Number of puma workers to spawn (default: 1; consider 2 for medium Heroku dynos, or 8 for large).
 
 ### Third Party Services
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -42,25 +42,6 @@ if workers_count > 1
   # process behavior so workers use less memory.
   #
   preload_app!
-
-  # The code in the `on_worker_boot` will be called if you are using
-  # clustered mode by specifying a number of `workers`. After each worker
-  # process is booted this block will be run, if you are using `preload_app!`
-  # option you will want to use this block to reconnect to any threads
-  # or connections that may have been created at application boot, Ruby
-  # cannot share connections between processes.
-  #
-  on_worker_boot do
-    ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-  end
-
-  # If you are preloading your application and using ActiveRecord, it's
-  # recommended that you close any connections to the database before workers
-  # are forked to prevent connection leakage.
-  #
-  before_fork do
-    ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
-  end
 end
 
 # Allow puma to be restarted by `rails restart` command.


### PR DESCRIPTION
For a while now, Rails has stopped recommending the `on_worker_boot` and `before_fork` code in the puma configuration. In particular, ActiveRecord now handles forks automatically, so this is no longer needed.

See:

https://github.com/rails/rails/commit/84cad15213ea5447ea0890a4f017b44ad85b901a

I also updated the README with recommended `WEB_CONCURRENCY` values, based on this Heroku documentation:

https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#recommended-default-puma-process-and-thread-configuration
