### PR TITLE
Remove spring-watcher-listen gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ group :development do
   gem "listen"
   gem "spring"
   gem "spring-commands-rspec"
-  gem "spring-watcher-listen"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,9 +274,6 @@ GEM
     spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -341,7 +338,6 @@ DEPENDENCIES
   slim-rails
   spring
   spring-commands-rspec
-  spring-watcher-listen
   webdrivers
   webpacker
 


### PR DESCRIPTION
Problem
=======
Remove the spring-watcher-listen gem.

This gem has not been published since 2016 (!) and is no longer recommended by the Rails team. It causes the node_modules directory to be watched, which can cause spring to go haywire and eat CPU.

See rails/rails#36377