### PR TITLE
Disable dependbot to try depfu

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,5 @@ updates:
       day: thursday
       time: "12:30"
       timezone: America/Los_Angeles
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     versioning-strategy: increase-if-necessary


### PR DESCRIPTION
https://depfu.com/ is an alternative to dependbot which appears to have some nice improvements. Let's give it a try.