### PR TITLE
Allow viewport to be scalable

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -5,7 +5,7 @@ html
     = stylesheet_pack_tag              "application", media: "all", "data-turbolinks-track": "reload"
     = javascript_packs_with_chunks_tag "application", 'data-turbolinks-track': 'reload'
     = csrf_meta_tag
-    meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    meta name="viewport" content="width=device-width, initial-scale=1.0"
 
   body id=(controller.controller_name) class=(controller.action_name)
     header.header


### PR DESCRIPTION
We performed an initial accessibility audit on our client project, and found that our generated layout disallows the user from scaling the viewport. The precise wording and explanation are available at https://web.dev/meta-viewport/.

I generated a fresh rails project and found these changes to be the new defaults.