### PR TITLE
Fix babel "loose" warnings

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -48,6 +48,12 @@ module.exports = function(api) {
         }
       ],
       [
+        require('@babel/plugin-proposal-private-methods').default,
+        {
+          loose: true
+        }
+      ],
+      [
         require('@babel/plugin-proposal-object-rest-spread').default,
         {
           useBuiltIns: true


### PR DESCRIPTION
This fixes the following warnings emitted by webpack:

```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
  ["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```

This matches the new default babel config suggested by webpacker:
https://github.com/rails/webpacker/pull/3016


### Steps to verify

1. Check out the `main` branch.
2. Delete `node_modules` and `public/packs*`.
3. Run `bin/setup`.
4. Run `bin/webpack`.
5. You'll see lots of warnings.
5. Check out this PR's branch.
6. Repeat steps 2, 3, 4.
7. You shouldn't see any warnings.