### PR TITLE
Use CircleCI Convenience Images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   rails:
     docker:
-      - image: circleci/ruby:3.0.2-node-browsers
+      - image: cimg/ruby:3.0.2-browsers
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_PATH: vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 orbs:
+  browser-tools: circleci/browser-tools@1.2.2
   node: circleci/node@4.0.0
   ruby: circleci/ruby@1.1.1
 
@@ -56,6 +57,8 @@ jobs:
     executor: rails
     steps:
       - checkout
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - install-dependencies
       - db-setup
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.2.2
-  node: circleci/node@4.0.0
-  ruby: circleci/ruby@1.1.1
+  node: circleci/node@4.7.0
+  ruby: circleci/ruby@1.1.4
 
 executors:
   rails:


### PR DESCRIPTION
CircleCI sent a notice that the images under the `circleci/*` namespace will stop receiving support at the end of the year. They are asking orgs to migrate to the "convenience" images, tagged as `cimg/*`.

This PR updates the template by following the [migration guide](https://circleci.com/docs/2.0/next-gen-migration-guide/).

# Orb Version Diff

The Ruby and Node orbs also get a version bump. Changes:

* https://github.com/CircleCI-Public/node-orb/compare/v4.0.0...v4.7.0
* https://github.com/CircleCI-Public/ruby-orb/compare/v1.1.1...v1.1.4