### PR TITLE
Send `cache-control: no-store` header by default

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  after_action :cache_control_no_store_by_default
+
+  private
+
+  def cache_control_no_store_by_default
+    response.cache_control[:no_store] = true if response.cache_control.empty?
+  end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -2,9 +2,16 @@ require "rails_helper"
 
 RSpec.describe PagesController do
   describe "GET 'root'" do
+    subject(:execute_request) { get "root" }
+
     it "returns http success" do
-      get "root"
+      execute_request
       expect(response).to be_successful
+    end
+
+    it "sends the cache-control header to disable browser caches" do
+      execute_request
+      expect(response.headers["Cache-Control"]).to eq("no-store")
     end
   end
 end


### PR DESCRIPTION
Problem
=======

When building apps and APIs, we typically want clients to have the most up to date data. If browsers cache highly dynamic responses, this can lead to inconsistencies for the user and other odd behavior.

By default, Rails adds this header to all responses:

```
Cache-Control: max-age=0, private, must-revalidate
```

This is a good middle ground. Combined with the `ETag` header (which Rails also generates), browsers are allowed to cache responses but *should* check with the server to make sure their cache is not stale. However, in practice it seems that browsers can be more aggressive with their caching, at their own discretion.

Solution
========

Browser caches cause frustrating bugs for highly dynamic apps. Fix this by sending this header instead:

```
Cache-Control: no-store
```

This disables all browser caching.

Note that there may still be cases where caching is desirable, e.g. to improve performance or where the resource is mostly static. Although the default is now `no-store`, you can still customize the cache headers per controller/action by using something like `fresh_when(..., public: true)` or revert to the Rails default with:

```ruby
skip_after_action :cache_control_no_store_by_default
```

Steps to Verify:
----------------
1. Run `bin/setup`
2. Run `yarn start` to start the app
3. Visit <http://localhost:3000>
4. Check the response headers in the browser dev tools
5. You should see `Cache-Control: no-store`

Screenshot
-----------

![Screen Shot 2021-09-29 at 11 18 21 AM](https://user-images.githubusercontent.com/189693/135326233-51942cbb-c522-4789-8333-bbe8fb7fa7f3.png)
