### PR TITLE
Add dependencies and a11y sections to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,25 @@
-# Problem
+Problem
+=======
 
 problem statement, including
 [link to Pivotal Tracker #12345678](https://www.pivotaltracker.com/story/show/12345678)
 
-# Solution
+Solution
+========
 
 What I/we did to solve this problem
 
 with @pairperson1
 
-## Change summary
+Change summary
+--------------
 
-- Tidy, well formulated commit message
-- Another great commit message
-- Something else I/we did
+* Tidy, well formulated commit message
+* Another great commit message
+* Something else I/we did
 
-## Steps to Verify
+Steps to Verify
+---------------
 
 1. A setup step / beginning state
 1. What to do next
@@ -25,18 +29,21 @@ with @pairperson1
 
 <!-- delete the following section if this PR adds no new dependencies -->
 
-## New Dependencies
+New Dependencies
+----------------
 
 Consider adding links to relevant listings from https://snyk.io or https://www.ruby-toolbox.com
 
 <!-- delete the following sections if this PR has no UI changes -->
 
-## Accessibility Checks
+Accessibility Checks
+--------------------
 
 - [ ] Text remains visible and feature is still functional even when browser is zoomed 200%
 - [ ] Feature is functional using purely keyboard-based interactions
 - [ ] Passes a Lighthouse audit (choose Lighthouse tab in Google Chrome devtools and run reports with **accessibility** selected, for both desktop and mobile)
 
-## Screenshots
+Screenshots
+-----------
 
 Show-n-tell images/animations here


### PR DESCRIPTION
# Problem + Solution

This commit makes some improvements to our standard GitHub pull request template. These changes have been used successfully on my current project and I think are worthy of backporting.

There are three changes of note:

1. ~~I've changed the formatting of the template to standard markdown syntax. In my experience markdown is more familiar to engineers than the reStructuredText syntax that was used before.~~
2. I added a dependencies section. When a new dependency is added to a project, this is worth calling out. In my experience it is worth using a site like snyk or ruby-toolbox to gauge the health of a library. The PR template is a good place to link to those health assessments.
3. Creating accessible apps is part of what we do as good software engineers, but it is helpful to be reminded so that accessibility bugs don't slip through the cracks. I've added a short checklist of things that are easy to test.
