### PR TITLE
Eager load in CI; remove non-functional ActionCable files

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,7 +1,0 @@
-# Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto
-# reloading.
-
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
-end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,7 +1,0 @@
-# Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto
-# reloading.
-
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
-end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,10 +11,10 @@ Rails.application.configure do
   config.cache_classes = false
   config.action_view.cache_template_loading = true
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
Problem
======

There can be load-ordering issues that only happen when eager loading is turned on. Currently, we disable eager loading in dev and test. That means we can get an unpleasant surprise in production.

Solution
======

Address this by turning eager loading on in CI. That guarantees we are testing the eager load scenario prior to production, but still keeping it off by default (for speed) in development and local testing.

This is a port of a new recommendation in Rails 7, but we can safely include it in our Rails 6.1 template.

https://github.com/rails/rails/pull/43508/files
