### PR TITLE
Fix babel "loose" config warnings (again!)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,78 +1,82 @@
-module.exports = function(api) {
-  var validEnv = ['development', 'test', 'production']
-  var currentEnv = api.env()
-  var isDevelopmentEnv = api.env('development')
-  var isProductionEnv = api.env('production')
-  var isTestEnv = api.env('test')
+module.exports = function (api) {
+  var validEnv = ["development", "test", "production"];
+  var currentEnv = api.env();
+  var isDevelopmentEnv = api.env("development");
+  var isProductionEnv = api.env("production");
+  var isTestEnv = api.env("test");
 
   if (!validEnv.includes(currentEnv)) {
     throw new Error(
-      'Please specify a valid `NODE_ENV` or ' +
+      "Please specify a valid `NODE_ENV` or " +
         '`BABEL_ENV` environment variables. Valid values are "development", ' +
         '"test", and "production". Instead, received: ' +
         JSON.stringify(currentEnv) +
-        '.'
-    )
+        "."
+    );
   }
 
   return {
     presets: [
       isTestEnv && [
-        require('@babel/preset-env').default,
+        "@babel/preset-env",
         {
           targets: {
-            node: 'current'
-          }
-        }
+            node: "current",
+          },
+        },
       ],
       (isProductionEnv || isDevelopmentEnv) && [
-        require('@babel/preset-env').default,
+        "@babel/preset-env",
         {
           forceAllTransforms: true,
-          useBuiltIns: 'entry',
+          useBuiltIns: "entry",
           corejs: 3,
           modules: false,
-          exclude: ['transform-typeof-symbol']
-        }
-      ]
+          exclude: ["transform-typeof-symbol"],
+        },
+      ],
     ].filter(Boolean),
     plugins: [
-      require('babel-plugin-macros'),
-      require('@babel/plugin-syntax-dynamic-import').default,
-      isTestEnv && require('babel-plugin-dynamic-import-node'),
-      require('@babel/plugin-transform-destructuring').default,
+      "babel-plugin-macros",
+      "@babel/plugin-syntax-dynamic-import",
+      isTestEnv && "babel-plugin-dynamic-import-node",
+      "@babel/plugin-transform-destructuring",
       [
-        require('@babel/plugin-proposal-class-properties').default,
+        "@babel/plugin-proposal-class-properties",
         {
-          loose: true
-        }
+          loose: true,
+        },
       ],
       [
-        require('@babel/plugin-proposal-private-methods').default,
+        "@babel/plugin-proposal-object-rest-spread",
         {
-          loose: true
-        }
+          useBuiltIns: true,
+        },
       ],
       [
-        require('@babel/plugin-proposal-object-rest-spread').default,
+        "@babel/plugin-proposal-private-methods",
         {
-          useBuiltIns: true
-        }
+          loose: true,
+        },
       ],
       [
-        require('@babel/plugin-transform-runtime').default,
+        "@babel/plugin-proposal-private-property-in-object",
+        {
+          loose: true,
+        },
+      ],
+      [
+        "@babel/plugin-transform-runtime",
         {
           helpers: false,
-          regenerator: true,
-          corejs: false
-        }
+        },
       ],
       [
-        require('@babel/plugin-transform-regenerator').default,
+        "@babel/plugin-transform-regenerator",
         {
-          async: false
-        }
-      ]
-    ].filter(Boolean)
-  }
-}
+          async: false,
+        },
+      ],
+    ].filter(Boolean),
+  };
+};


### PR DESCRIPTION
# Problem

Running webpack prints these warnings:

```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-methods.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
  ["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
to the "plugins" section of your Babel config.
```

# Solution

This is due to the `babel.config.js` that is generated by webpacker. The problem has been fixed upstream.

Solution is to regenerate `babel.config.js` using the latest version of webpacker that we are using (5.4.3).

## Steps to verify

1. Delete `node_modules`.
2. Run `bin/setup`.
3. Run `bin/webpack`.
4. Confirm that no "loose" warnings are printed.
