### PR TITLE
Do not run db:seed prior to RSpec in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,13 @@ commands:
       - node/install-packages:
           pkg-manager: yarn
   db-setup:
-    description: Set up database
+    description: Create database
     steps:
       # Using structure.sql? Install postgresql-client for loading structure.
       #- run: sudo apt-get install postgresql-client
       - run:
-          name: Set up database
-          command: bundle exec rake db:setup
+          name: Create database
+          command: bundle exec rake db:create
 
 jobs:
   install_dependencies:
@@ -54,8 +54,16 @@ jobs:
       - db-setup
       - ruby/rubocop-check
       - run:
-          # Ensure sample_data runs without issues
-          name: Seed with sample data
+          # Ensure db:migrate runs without issues
+          name: Migrate database
+          command: bin/rails db:migrate
+      - run:
+          # Ensure db:seed runs without issues
+          name: Load seeds
+          command: bin/rails db:seed
+      - run:
+          # Ensure db:sample_data runs without issues
+          name: Load sample data
           command: bin/rails db:sample_data
   rspec:
     executor: rails


### PR DESCRIPTION
Problem
=======

As a general practice, the test database should be in a known clean (empty) state prior to running tests. This is how tests work in a local development environment.

However, in CircleCI, we have been running this prior to tests:

```
RAILS_ENV=test rake db:setup
```

This does three things behind the scenes:

1. Create the database
2. Load the schema from `db/schema.rb`
3. Run `db:seed` to load seed data

We do _not_ want step 3, because it means the database will be in a different state in CI (i.e. seeds loaded) than in local development (no seeds loaded). This can cause tests to fail in CI but pass in local development, or vice versa.

Solution
========

Fix by changing `db:setup` to `db:create`. The `rails_helper.rb` already will ensure that the schema is loaded via the following line, so we don't need to load the schema explicitly:

```
ActiveRecord::Migration.maintain_test_schema!
```

It is still important to load seeds in CI just to test that they actually work. It is also important to test that db migrations work. Run these as part of other our steps in the `static_analysis` job.