### PR TITLE
Enable gzip for responses generated by the app

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,10 @@ module AppPrototype
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
+    # Enable gzip for dynamically generated HTML and API responses.
+    # Remove if NGNIX, Cloudflare, or similar reverse-proxy is in place that already provides gzip.
+    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
+
     # Enable/disable generators.
     config.generators do |g|
       # Core Rails


### PR DESCRIPTION
Problem
=======

Gzip is commonly used to improve app performance by greatly reducing the amount of data sent over the wire (typically 80%+), at the expense of some CPU cost for performing the compression.

Implementing gzip usually takes two forms:

1. Compressing static assets. CSS and JS are highly-compressable. The Rails asset pipeline and webpacker already take care of compressing during the assets:precompile phase. At runtime, when Rails is serving static assets, it detects the pre-compressed versions and serves them. This is already happening by default, so there is nothing we need to do to opt into it.
2. Compressing dynamic responses (i.e. HTML/JSON/etc. rendered from controllers and views). By definition, these cannot be "pre-compressed". Rails does not gzip these responses by default.

Solution
========

This PR adds compression for type (2) as described above, by enabling the `Rack::Deflator` middleware. For a more detailed explanation, see this blog post:

https://www.schneems.com/2017/11/08/80-smaller-rails-footprint-with-rack-deflate/

Steps to Verify
---------------

1. Run the app locally
1. Load <http://localhost:3000>
1. Inspect the response headers; you should see `Content-Encoding: gzip`

Screenshots
-----------

![Screen Shot 2022-05-25 at 9 19 59 AM](https://user-images.githubusercontent.com/189693/170311276-c8b8f999-7837-4133-9bc3-0701a78f6bb7.png)

