### PR TITLE
Add faker gem and ensure unique generators are reset

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ end
 group :development, :test do
   gem "byebug"
   gem "factory_bot_rails"
+  gem "faker"
   gem "rspec_junit_formatter", require: false
   gem "rspec-rails"
   gem "rubocop", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.23.0)
+      i18n (>= 1.8.11, < 2)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -298,6 +300,7 @@ DEPENDENCIES
   capybara
   dotenv-rails
   factory_bot_rails
+  faker
   launchy
   pg
   puma

--- a/spec/support/faker.rb
+++ b/spec/support/faker.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.after do
+    Faker::UniqueGenerator.clear
+  end
+end


### PR DESCRIPTION
Proposal
=======

Faker has its pros and cons. On the pro side, using randomly generated data is an easy way to broaden test coverage for cases you might not think to test manually (e.g. what happens when there is an apostrophe in user.last_name?).

The downside is that faker makes it easy to build factories containing nonsense data that don't represent real world use cases, and this can lead to flaky tests.

It's also possible, when building many factory objects that have unique constraints, to exhaust faker's pool of values, which can also lead to unreliable tests.

That said, every Rails project I can remember working on has used faker, and I think the pros outweight the cons. It is often one of the first gems I add to an app generated by raygun.

This commit adds the faker gem to the Gemfile and sets up an after-hook in RSpec to address the problem of running out of unique values.

New Dependencies
----------------

`faker` is well-maintained and extremely popular according to Ruby Toolbox:

https://www.ruby-toolbox.com/projects/faker
