### PR TITLE
Use correct homebrew package for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To run the specs or fire up the server, be sure you have these installed (and ru
 * Ruby 3.0 (see [.ruby-version](.ruby-version)).
 * Node 16 (see [.node-version](.node-version)).
 * Yarn 1.x (`npm install -g yarn`).
-* PostgreSQL 13.1+. (`brew install postgresql`).
+* PostgreSQL 14+. (`brew install postgresql@14`).
 
 To manage deployments you will need:
 


### PR DESCRIPTION
Problem+Solution
=======

The homebrew `postgres` package has been removed in favor of packages that are pinned at major versions. 

```
$ brew info postgres
Error: No available formula with the name "postgres". Did you mean postgrest or postgis?
postgresql breaks existing databases on upgrade without human intervention.

See a more specific version to install with:
  brew formulae | grep postgresql@
```
Currently, the way to install PostgreSQL via homebrew is to use `brew install postgresql@14`.

This commit updates our README to reflect this.
