### PR TITLE
Fix "no such middleware" error in production mode

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,10 +32,6 @@ module AppPrototype
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # Enable gzip for dynamically generated HTML and API responses.
-    # Remove if NGNIX, Cloudflare, or similar reverse-proxy is in place that already provides gzip.
-    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
-
     # Enable/disable generators.
     config.generators do |g|
       # Core Rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,9 +20,17 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  if ENV["RAILS_SERVE_STATIC_FILES"].present?
+    config.public_file_server.enabled = true
+
+    # Enable gzip for dynamically generated HTML and API responses.
+    # Remove if NGNIX, Cloudflare, or similar reverse-proxy is in place that already provides gzip.
+    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
+  else
+    # Disable serving static files from the `/public` folder by default since
+    # Apache or NGINX already handles this.
+    config.public_file_server.enabled = false
+  end
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = ENV["ASSET_HOST"].presence


### PR DESCRIPTION
Problem
=======

If the app is run in production and `RAILS_SERVE_STATIC_FILES` is **not** set, the app fails to boot with this error:

```
No such middleware to insert after: ActionDispatch::Static
config/environment.rb:5:in `<main>'
Tasks: TOP => assets:precompile => webpacker:compile => environment
(See full trace by running task with --trace)
```

That's because the `ActionDispatch::Static` middleware only exists in production if the `config.public_file_server` value is set to true. If `RAILS_SERVE_STATIC_FILES` is not present, it is set to false, and thus the middleware doesn't exist.

Solution
========

Move the `Rack::Deflater` setup into `production.rb` alongside the `config.public_file_server` setting, so that the middlware is only inserted when the latter is set to true.

Steps to Verify
---------------

1. Run `SECRET_KEY_BASE=placeholder RAILS_ENV=production bin/rails assets:precompile`
2. Confirm assets are compiled without errors (this shows the app is able to boot in production mode)
