### PR TITLE
Pin puma 5.x since Rails doesn't support puma 6 yet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby "3.1.2"
 gem "amazing_print"
 gem "bootsnap", require: false
 gem "pg"
-gem "puma"
+gem "puma", "~> 5.6" # Rails doesn't yet support puma 6 as of rails 7.0
 gem "rack-canonical-host"
 gem "rails", "~> 7.0.3"
 gem "simple_form"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,7 +300,7 @@ DEPENDENCIES
   factory_bot_rails
   launchy
   pg
-  puma
+  puma (~> 5.6)
   rack-canonical-host
   rack-timeout
   rails (~> 7.0.3)


### PR DESCRIPTION
Problem
=======

Puma 6 has been released. Rails support for Puma 6 is coming (see https://github.com/rails/rails/pull/46106) but for now Rails 7.0 does not fully support it.

Depfu is trying to update puma (see #718) and the build fails.

We need to pin puma so that it is not included in the automated dependency updates.

Solution
========

Pin to puma ~> 5.x in our Gemfile.